### PR TITLE
Clang 9 bug workaround

### DIFF
--- a/gcc/genconditions.c
+++ b/gcc/genconditions.c
@@ -57,8 +57,9 @@ write_header (void)
 \n\
 /* It is necessary, but not entirely safe, to include the headers below\n\
    in a generator program.  As a defensive measure, don't do so when the\n\
-   table isn't going to have anything in it.  */\n\
-#if GCC_VERSION >= 3001\n\
+   table isn't going to have anything in it.\n\
+   Clang 9 is buggy and doesn't handle __builtin_constant_p correctly.  */\n\
+#if GCC_VERSION >= 3001 && __clang_major__ < 9\n\
 \n\
 /* Do not allow checking to confuse the issue.  */\n\
 #undef CHECKING_P\n\
@@ -170,7 +171,7 @@ struct c_test\n\
    vary at run time.  It works in 3.0.1 and later; 3.0 only when not\n\
    optimizing.  */\n\
 \n\
-#if GCC_VERSION >= 3001\n\
+#if GCC_VERSION >= 3001 && __clang_major__ < 9\n\
 static const struct c_test insn_conditions[] = {\n");
 
   traverse_c_tests (write_one_condition, 0);
@@ -191,7 +192,7 @@ write_writer (void)
 	"  unsigned int i;\n"
         "  const char *p;\n"
         "  puts (\"(define_conditions [\");\n"
-	"#if GCC_VERSION >= 3001\n"
+	"#if GCC_VERSION >= 3001 && __clang_major__ < 9\n"
 	"  for (i = 0; i < ARRAY_SIZE (insn_conditions); i++)\n"
 	"    {\n"
 	"      printf (\"  (%d \\\"\", insn_conditions[i].value);\n"


### PR DESCRIPTION
Clang 9 has a bug in which it reports a `GCC_VERSION` greater than or
equal to 300 yet does not implement `__builtin_constant_p` as does GCC.

This workaround ensures that `__builtin_constant_p` is not used when
building with Clang 9.

For more details, refer to the linked GCC bug [1].

Note that this workaround is required for building GCC 10.3 on the
macOS 11 and above.

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92061

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>