### PR TITLE
RISC-V: Add base instruction set multilibs

### DIFF
--- a/gcc/config/riscv/t-zephyr
+++ b/gcc/config/riscv/t-zephyr
@@ -1,21 +1,37 @@
 # Multilib target configurations
-MULTILIB_SRC_ARCH  = rv32im_zicsr_zifencei
-MULTILIB_SRC_ARCH += rv32imc_zicsr_zifencei
+MULTILIB_SRC_ARCH  = rv32i_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv32im_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv32ima_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv32imac_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv32imafc_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv32imafd_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv32imafdc_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv32imc_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv32ia_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv32iac_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv32ic_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv32g
 MULTILIB_SRC_ARCH += rv32gc
+MULTILIB_SRC_ARCH += rv32e_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv32em_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv32ema_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv32emc_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv32emac_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv32ea_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv32eac_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv32ec_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv64i_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv64im_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv64ima_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv64imac_zicsr_zifencei
-MULTILIB_SRC_ARCH += rv64imafdc_zicsr_zifencei
-MULTILIB_SRC_ARCH += rv64gc
 MULTILIB_SRC_ARCH += rv64imafd_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv64imafdc_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv64imc_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv64ia_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv64iac_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv64ic_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv64g
+MULTILIB_SRC_ARCH += rv64gc
 
 MULTILIB_SRC_ABI  = ilp32
 MULTILIB_SRC_ABI += ilp32f
@@ -28,12 +44,15 @@ MULTILIB_SRC_MCMODEL  = medany
 
 # Multilib build configurations
 MULTILIB_REQUIRED = \
+march=rv32i_zicsr_zifencei/mabi=ilp32 \
 march=rv32im_zicsr_zifencei/mabi=ilp32 \
 march=rv32imac_zicsr_zifencei/mabi=ilp32 \
 march=rv32imafc_zicsr_zifencei/mabi=ilp32f \
 march=rv32imafd_zicsr_zifencei/mabi=ilp32d \
+march=rv32e_zicsr_zifencei/mabi=ilp32e \
 march=rv32em_zicsr_zifencei/mabi=ilp32e \
 march=rv32emc_zicsr_zifencei/mabi=ilp32e \
+march=rv64i_zicsr_zifencei/mabi=lp64 \
 march=rv64imac_zicsr_zifencei/mabi=lp64 \
 march=rv64imafdc_zicsr_zifencei/mabi=lp64d \
 march=rv64imafd_zicsr_zifencei/mabi=lp64d \
@@ -43,12 +62,25 @@ march=rv64imafd_zicsr_zifencei/mabi=lp64d/mcmodel=medany
 
 # Multilib alternate mapping
 MULTILIB_REUSE = \
+march.rv32i_zicsr_zifencei/mabi.ilp32=march.rv32ia_zicsr_zifencei/mabi.ilp32 \
+march.rv32i_zicsr_zifencei/mabi.ilp32=march.rv32iac_zicsr_zifencei/mabi.ilp32 \
+march.rv32i_zicsr_zifencei/mabi.ilp32=march.rv32ic_zicsr_zifencei/mabi.ilp32 \
+march.rv32im_zicsr_zifencei/mabi.ilp32=march.rv32ima_zicsr_zifencei/mabi.ilp32 \
 march.rv32im_zicsr_zifencei/mabi.ilp32=march.rv32imc_zicsr_zifencei/mabi.ilp32 \
 march.rv32imafd_zicsr_zifencei/mabi.ilp32d=march.rv32imafdc_zicsr_zifencei/mabi.ilp32d \
 march.rv32imafd_zicsr_zifencei/mabi.ilp32d=march.rv32g/mabi.ilp32d \
 march.rv32imafd_zicsr_zifencei/mabi.ilp32d=march.rv32gc/mabi.ilp32d \
+march.rv32e_zicsr_zifencei/mabi.ilp32e=march.rv32ea_zicsr_zifencei/mabi.ilp32e \
+march.rv32e_zicsr_zifencei/mabi.ilp32e=march.rv32eac_zicsr_zifencei/mabi.ilp32e \
+march.rv32e_zicsr_zifencei/mabi.ilp32e=march.rv32ec_zicsr_zifencei/mabi.ilp32e \
 march.rv32em_zicsr_zifencei/mabi.ilp32e=march.rv32ema_zicsr_zifencei/mabi.ilp32e \
 march.rv32emc_zicsr_zifencei/mabi.ilp32e=march.rv32emac_zicsr_zifencei/mabi.ilp32e \
+march.rv64i_zicsr_zifencei/mabi.lp64=march.rv64im_zicsr_zifencei/mabi.lp64 \
+march.rv64i_zicsr_zifencei/mabi.lp64=march.rv64ima_zicsr_zifencei/mabi.lp64 \
+march.rv64i_zicsr_zifencei/mabi.lp64=march.rv64imc_zicsr_zifencei/mabi.lp64 \
+march.rv64i_zicsr_zifencei/mabi.lp64=march.rv64ia_zicsr_zifencei/mabi.lp64 \
+march.rv64i_zicsr_zifencei/mabi.lp64=march.rv64iac_zicsr_zifencei/mabi.lp64 \
+march.rv64i_zicsr_zifencei/mabi.lp64=march.rv64ic_zicsr_zifencei/mabi.lp64 \
 march.rv64imafdc_zicsr_zifencei/mabi.lp64d=march.rv64gc/mabi.lp64d \
 march.rv64imafd_zicsr_zifencei/mabi.lp64d=march.rv64g/mabi.lp64d
 


### PR DESCRIPTION
This commit adds the following base instruction set multilibs that can
be used for every practical extension permutation:

* rv32i_zicsr_zifencei
* rv32e_zicsr_zifencei
* rv64i_zicsr_zifencei

These base instruction set multilibs are mapped to the compatible
extension permutations that do not have a dedicated multilib in order
to increase the ISA coverage of the toolchain.

Note that the Zicsr and Zifencei extensions are still specified for the
base instruction set multilibs because the Zephyr RISC-V architecture
port requires them and it is not practical to configure a RISC-V core
that does not support these instruction sets.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>