### PR TITLE
arc: Fix enter pattern instruction's offsets

### DIFF
--- a/gcc/config/arc/arc.cc
+++ b/gcc/config/arc/arc.cc
@@ -3350,7 +3350,7 @@ arc_save_callee_enter (uint64_t gmask,
       reg = gen_rtx_REG (Pmode, RETURN_ADDR_REGNUM);
       mem = gen_frame_mem (Pmode, plus_constant (Pmode,
 						 stack_pointer_rtx,
-						 off));
+						 -off));
       XVECEXP (insn, 0, indx) = gen_rtx_SET (mem, reg);
       RTX_FRAME_RELATED_P (XVECEXP (insn, 0, indx++)) = 1;
       off -= UNITS_PER_WORD;
@@ -3364,7 +3364,7 @@ arc_save_callee_enter (uint64_t gmask,
       reg = gen_rtx_REG (SImode, regno);
       mem = gen_frame_mem (SImode, plus_constant (Pmode,
 						  stack_pointer_rtx,
-						  off));
+						  -off));
       XVECEXP (insn, 0, indx) = gen_rtx_SET (mem, reg);
       RTX_FRAME_RELATED_P (XVECEXP (insn, 0, indx)) = 1;
       gmask = gmask & ~(1ULL << regno);
@@ -3374,7 +3374,7 @@ arc_save_callee_enter (uint64_t gmask,
     {
       mem = gen_frame_mem (Pmode, plus_constant (Pmode,
 						 stack_pointer_rtx,
-						 off));
+						 -off));
       XVECEXP (insn, 0, indx) = gen_rtx_SET (mem, hard_frame_pointer_rtx);
       RTX_FRAME_RELATED_P (XVECEXP (insn, 0, indx++)) = 1;
       off -= UNITS_PER_WORD;

--- a/gcc/testsuite/gcc.target/arc/enter-dw2-1.c
+++ b/gcc/testsuite/gcc.target/arc/enter-dw2-1.c
@@ -1,0 +1,28 @@
+/* Verify that we generate appropriate CFI offsets in the case of enter
+   instruction.  */
+/* { dg-skip-if "Not having enter_s insn." { arc700 || arc6xx } } */
+/* { dg-do compile } */
+/* { dg-options "-g -Os" } */
+
+extern void bar (void);
+
+void foo (void)
+{
+  asm volatile (";my clobber list"
+		: : : "r13", "r14", "r15", "r16", "r17", "r18", "r19");
+  bar ();
+  asm volatile (";my clobber list"
+		: : : "r13", "r14", "r15", "r16", "r17", "r18", "r19");
+}
+
+
+/* { dg-final { scan-assembler-times "enter_s" 1 } } */
+/* { dg-final { scan-assembler-times "\.cfi_def_cfa_offset 32" 1 } } */
+/* { dg-final { scan-assembler-times "\.cfi_offset 31, -32" 1 } } */
+/* { dg-final { scan-assembler-times "\.cfi_offset 13, -28" 1 } } */
+/* { dg-final { scan-assembler-times "\.cfi_offset 14, -24" 1 } } */
+/* { dg-final { scan-assembler-times "\.cfi_offset 15, -20" 1 } } */
+/* { dg-final { scan-assembler-times "\.cfi_offset 16, -16" 1 } } */
+/* { dg-final { scan-assembler-times "\.cfi_offset 17, -12" 1 } } */
+/* { dg-final { scan-assembler-times "\.cfi_offset 18, -8" 1 } } */
+/* { dg-final { scan-assembler-times "\.cfi_offset 19, -4" 1 } } */


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/47985 via https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/issues/471 via https://github.com/foss-for-synopsys-dwc-arc-processors/gcc/commit/7af69aabd1c39efdcaf18ff99c75da57f936562e.