### PR TITLE
Revert "AArch64: Cleanup aarch64_classify_symbol"

### DIFF
--- a/gcc/config/aarch64/aarch64.cc
+++ b/gcc/config/aarch64/aarch64.cc
@@ -19270,14 +19270,7 @@ aarch64_classify_symbol (rtx x, HOST_WIDE_INT offset)
 
       switch (aarch64_cmodel)
 	{
-	case AARCH64_CMODEL_TINY_PIC:
 	case AARCH64_CMODEL_TINY:
-	  /* With -fPIC non-local symbols use the GOT.  For orthogonality
-	     always use the GOT for extern weak symbols.  */
-	  if ((flag_pic || SYMBOL_REF_WEAK (x))
-	      && !aarch64_symbol_binds_local_p (x))
-	    return SYMBOL_TINY_GOT;
-
 	  /* When we retrieve symbol + offset address, we have to make sure
 	     the offset does not cause overflow of the final address.  But
 	     we have no way of knowing the address of symbol at compile time
@@ -19285,28 +19278,40 @@ aarch64_classify_symbol (rtx x, HOST_WIDE_INT offset)
 	     symbol + offset is outside the addressible range of +/-1MB in the
 	     TINY code model.  So we limit the maximum offset to +/-64KB and
 	     assume the offset to the symbol is not larger than +/-(1MB - 64KB).
-	     If offset_within_block_p is true we allow larger offsets.  */
+	     If offset_within_block_p is true we allow larger offsets.
+	     Furthermore force to memory if the symbol is a weak reference to
+	     something that doesn't resolve to a symbol in this module.  */
+
+	  if (SYMBOL_REF_WEAK (x) && !aarch64_symbol_binds_local_p (x))
+	    return SYMBOL_FORCE_TO_MEM;
 	  if (!(IN_RANGE (offset, -0x10000, 0x10000)
 		|| offset_within_block_p (x, offset)))
 	    return SYMBOL_FORCE_TO_MEM;
 
 	  return SYMBOL_TINY_ABSOLUTE;
 
-
-	case AARCH64_CMODEL_SMALL_SPIC:
-	case AARCH64_CMODEL_SMALL_PIC:
 	case AARCH64_CMODEL_SMALL:
-	  if ((flag_pic || SYMBOL_REF_WEAK (x))
-	      && !aarch64_symbol_binds_local_p (x))
-	    return aarch64_cmodel == AARCH64_CMODEL_SMALL_SPIC
-		    ? SYMBOL_SMALL_GOT_28K : SYMBOL_SMALL_GOT_4G;
-
 	  /* Same reasoning as the tiny code model, but the offset cap here is
 	     1MB, allowing +/-3.9GB for the offset to the symbol.  */
+
+	  if (SYMBOL_REF_WEAK (x) && !aarch64_symbol_binds_local_p (x))
+	    return SYMBOL_FORCE_TO_MEM;
 	  if (!(IN_RANGE (offset, -0x100000, 0x100000)
 		|| offset_within_block_p (x, offset)))
 	    return SYMBOL_FORCE_TO_MEM;
 
+	  return SYMBOL_SMALL_ABSOLUTE;
+
+	case AARCH64_CMODEL_TINY_PIC:
+	  if (!aarch64_symbol_binds_local_p (x))
+	    return SYMBOL_TINY_GOT;
+	  return SYMBOL_TINY_ABSOLUTE;
+
+	case AARCH64_CMODEL_SMALL_SPIC:
+	case AARCH64_CMODEL_SMALL_PIC:
+	  if (!aarch64_symbol_binds_local_p (x))
+	    return (aarch64_cmodel == AARCH64_CMODEL_SMALL_SPIC
+		    ?  SYMBOL_SMALL_GOT_28K : SYMBOL_SMALL_GOT_4G);
 	  return SYMBOL_SMALL_ABSOLUTE;
 
 	case AARCH64_CMODEL_LARGE:


### PR DESCRIPTION
This reverts the commit fb0746f3a6b7fd0223efa71d0dc3fc02166e338b
because it causes the "GOT indirections," which require the final image
to include the Global Offset Table (GOT), to be emitted for weak symbol
references even when not building position-independent code or
position-independent executable (i.e. when `-fno-pic` and `-fno-pie`
parameters are specified).

Before reverting this commit (GCC 12.1):

  adrp    x0, :got:pm_state_exit_post_ops
  ldr     x0, [x0, :got_lo12:pm_state_exit_post_ops]

After reverting this commit (before GCC 12.1):

  adrp    x0, .LC0
  ldr     x0, [x0, #:lo12:.LC0]
  ...
.LC0:
  .xword  pm_state_exit_post_ops

Although the linker populates the Global Offset Table with the symbol
addresses at the default linking address, which should be valid without
any relocations in case of Zephyr because the Zephyr image is always
loaded at a fixed address, this is far from ideal because the purpose
of the Global Offset Table is to facilitate relocations and it comes
with some overheads resulting in a minor footprint increase.

For more details, refer to the following GitHub issue:
zephyrproject-rtos/sdk-ng#547.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>