### PR TITLE
arm: Skip FP clobber warning on Cortex-M

### DIFF
--- a/gcc/config/arm/arm.cc
+++ b/gcc/config/arm/arm.cc
@@ -7394,7 +7394,7 @@ arm_handle_isr_attribute (tree *node, tree name, tree args, int flags,
 		   name);
 	  *no_add_attrs = true;
 	}
-      else if (TARGET_VFP_BASE)
+      else if (TARGET_VFP_BASE && arm_arch_notm)
 	{
 	  warning (OPT_Wattributes, "FP registers might be clobbered despite %qE attribute: compile with %<-mgeneral-regs-only%>",
 		   name);


### PR DESCRIPTION
Skips the FP stack clobbering warning when compiling for Cortex-M
targets, which don't have the same stack-handling requirements inside
ISRs.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/49631