### PR TITLE
riscv: support RV32IAFC

### DIFF
--- a/gcc/config/riscv/t-zephyr
+++ b/gcc/config/riscv/t-zephyr
@@ -13,6 +13,7 @@ MULTILIB_SRC_ARCH += rv32imc_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv32imc_zicsr_zifencei_zba_zbb_zbc_zbs
 MULTILIB_SRC_ARCH += rv32ia_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv32iac_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv32iafc_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv32ic_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv32g
 MULTILIB_SRC_ARCH += rv32gc
@@ -76,6 +77,7 @@ march=rv64imafd_zicsr_zifencei/mabi=lp64d/mcmodel=medany
 MULTILIB_REUSE = \
 march.rv32i_zicsr_zifencei/mabi.ilp32=march.rv32ia_zicsr_zifencei/mabi.ilp32 \
 march.rv32i_zicsr_zifencei/mabi.ilp32=march.rv32iac_zicsr_zifencei/mabi.ilp32 \
+march.rv32i_zicsr_zifencei/mabi.ilp32=march.rv32iafc_zicsr_zifencei/mabi.ilp32 \
 march.rv32i_zicsr_zifencei/mabi.ilp32=march.rv32ic_zicsr_zifencei/mabi.ilp32 \
 march.rv32im_zicsr_zifencei/mabi.ilp32=march.rv32ima_zicsr_zifencei/mabi.ilp32 \
 march.rv32im_zicsr_zifencei/mabi.ilp32=march.rv32imc_zicsr_zifencei/mabi.ilp32 \


### PR DESCRIPTION
This adds a multilib alias for rv32iafc that reuses the libraries for
rv32i. This is useful for IT8xxx2, which has a FPU but cannot use the -M
extension.

Signed-off-by: Peter Marheine <pmarheine@chromium.org>