### PR TITLE
RISC-V: Add rv32if/ilp32f multilib variant

### DIFF
--- a/gcc/config/riscv/t-zephyr
+++ b/gcc/config/riscv/t-zephyr
@@ -14,6 +14,7 @@ MULTILIB_SRC_ARCH += rv32imc_zicsr_zifencei_zba_zbb_zbc_zbs
 MULTILIB_SRC_ARCH += rv32ia_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv32iac_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv32iafc_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv32if_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv32ic_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv32g
 MULTILIB_SRC_ARCH += rv32gc
@@ -61,6 +62,7 @@ march=rv32im_zicsr_zifencei_zba_zbb_zbc_zbs/mabi=ilp32 \
 march=rv32imac_zicsr_zifencei/mabi=ilp32 \
 march=rv32imafc_zicsr_zifencei/mabi=ilp32f \
 march=rv32imafd_zicsr_zifencei/mabi=ilp32d \
+march=rv32if_zicsr_zifencei/mabi=ilp32f \
 march=rv32e_zicsr_zifencei/mabi=ilp32e \
 march=rv32em_zicsr_zifencei/mabi=ilp32e \
 march=rv32emc_zicsr_zifencei/mabi=ilp32e \
@@ -87,6 +89,7 @@ march.rv32im_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.ilp32=march.rv32imc_zicsr_zifen
 march.rv32imafd_zicsr_zifencei/mabi.ilp32d=march.rv32imafdc_zicsr_zifencei/mabi.ilp32d \
 march.rv32imafd_zicsr_zifencei/mabi.ilp32d=march.rv32g/mabi.ilp32d \
 march.rv32imafd_zicsr_zifencei/mabi.ilp32d=march.rv32gc/mabi.ilp32d \
+march.rv32if_zicsr_zifencei/mabi.ilp32f=march.rv32iafc_zicsr_zifencei/mabi.ilp32f \
 march.rv32e_zicsr_zifencei/mabi.ilp32e=march.rv32ea_zicsr_zifencei/mabi.ilp32e \
 march.rv32e_zicsr_zifencei/mabi.ilp32e=march.rv32eac_zicsr_zifencei/mabi.ilp32e \
 march.rv32e_zicsr_zifencei/mabi.ilp32e=march.rv32ec_zicsr_zifencei/mabi.ilp32e \


### PR DESCRIPTION
This commit adds a new "base" multilib variant, rv32if/ilp32f, that can be used across the rv32i*f*/ilp32f targets, including rv32iafc/ilp32f.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

NOTE: This addresses https://github.com/zephyrproject-rtos/gcc/pull/14#discussion_r957951682.