### PR TITLE
libstdc++: Allow C99 long double math functions to be optional

### DIFF
--- a/libstdc++-v3/acinclude.m4
+++ b/libstdc++-v3/acinclude.m4
@@ -1819,117 +1819,131 @@ AC_DEFUN([GLIBCXX_CHECK_C99_TR1], [
 		  typedef float_t   my_float_t;
 		  acosh(0.0);
 		  acoshf(0.0f);
-		  acoshl(0.0l);
 		  asinh(0.0);
 		  asinhf(0.0f);
-		  asinhl(0.0l);
 		  atanh(0.0);
 		  atanhf(0.0f);
-		  atanhl(0.0l);
 		  cbrt(0.0);
 		  cbrtf(0.0f);
-		  cbrtl(0.0l);
 		  copysign(0.0, 0.0);
 		  copysignf(0.0f, 0.0f);
-		  copysignl(0.0l, 0.0l);
 		  erf(0.0);
 		  erff(0.0f);
-		  erfl(0.0l);
 		  erfc(0.0);
 		  erfcf(0.0f);
-		  erfcl(0.0l);
 		  exp2(0.0);
 		  exp2f(0.0f);
-		  exp2l(0.0l);
 		  expm1(0.0);
 		  expm1f(0.0f);
-		  expm1l(0.0l);
 		  fdim(0.0, 0.0);
 		  fdimf(0.0f, 0.0f);
-		  fdiml(0.0l, 0.0l);
 		  fma(0.0, 0.0, 0.0);
 		  fmaf(0.0f, 0.0f, 0.0f);
-		  fmal(0.0l, 0.0l, 0.0l);
 		  fmax(0.0, 0.0);
 		  fmaxf(0.0f, 0.0f);
-		  fmaxl(0.0l, 0.0l);
 		  fmin(0.0, 0.0);
 		  fminf(0.0f, 0.0f);
-		  fminl(0.0l, 0.0l);
 		  hypot(0.0, 0.0);
 		  hypotf(0.0f, 0.0f);
-		  hypotl(0.0l, 0.0l);
 		  ilogb(0.0);
 		  ilogbf(0.0f);
-		  ilogbl(0.0l);
 		  lgamma(0.0);
 		  lgammaf(0.0f);
-		  lgammal(0.0l);
 		  #ifndef __APPLE__ /* see below */
 		  llrint(0.0);
 		  llrintf(0.0f);
-		  llrintl(0.0l);
 		  llround(0.0);
 		  llroundf(0.0f);
-		  llroundl(0.0l);
 		  #endif
 		  log1p(0.0);
 		  log1pf(0.0f);
-		  log1pl(0.0l);
 		  log2(0.0);
 		  log2f(0.0f);
-		  log2l(0.0l);
 		  logb(0.0);
 		  logbf(0.0f);
-		  logbl(0.0l);
 		  lrint(0.0);
 		  lrintf(0.0f);
-		  lrintl(0.0l);
 		  lround(0.0);
 		  lroundf(0.0f);
-		  lroundl(0.0l);
 		  nan(0);
 		  nanf(0);
-		  nanl(0);
 		  nearbyint(0.0);
 		  nearbyintf(0.0f);
-		  nearbyintl(0.0l);
 		  nextafter(0.0, 0.0);
 		  nextafterf(0.0f, 0.0f);
-		  nextafterl(0.0l, 0.0l);
-		  nexttoward(0.0, 0.0);
-		  nexttowardf(0.0f, 0.0f);
-		  nexttowardl(0.0l, 0.0l);
 		  remainder(0.0, 0.0);
 		  remainderf(0.0f, 0.0f);
-		  remainderl(0.0l, 0.0l);
 		  remquo(0.0, 0.0, 0);
 		  remquof(0.0f, 0.0f, 0);
-		  remquol(0.0l, 0.0l, 0);
 		  rint(0.0);
 		  rintf(0.0f);
-		  rintl(0.0l);
 		  round(0.0);
 		  roundf(0.0f);
-		  roundl(0.0l);
 		  scalbln(0.0, 0l);
 		  scalblnf(0.0f, 0l);
-		  scalblnl(0.0l, 0l);
 		  scalbn(0.0, 0);
 		  scalbnf(0.0f, 0);
-		  scalbnl(0.0l, 0);
 		  tgamma(0.0);
 		  tgammaf(0.0f);
-		  tgammal(0.0l);
 		  trunc(0.0);
 		  truncf(0.0f);
-		  truncl(0.0l);
 		 ],[glibcxx_cv_c99_math_tr1=yes], [glibcxx_cv_c99_math_tr1=no])
   ])
   if test x"$glibcxx_cv_c99_math_tr1" = x"yes"; then
     AC_DEFINE(_GLIBCXX_USE_C99_MATH_TR1, 1,
 	      [Define if C99 functions or macros in <math.h> should be imported
 	      in <tr1/cmath> in namespace std::tr1.])
+
+    AC_CACHE_CHECK([for ISO C99 long double math functions in <math.h>],
+      glibcxx_cv_c99_math_long_double, [
+      AC_TRY_COMPILE([#include <math.h>],
+		[acoshl(0.0l);
+		 asinhl(0.0l);
+		 atanhl(0.0l);
+		 cbrtl(0.0l);
+		 copysignl(0.0l, 0.0l);
+		 erfl(0.0l);
+		 erfcl(0.0l);
+		 exp2l(0.0l);
+		 expm1l(0.0l);
+		 fdiml(0.0l, 0.0l);
+		 fmal(0.0l, 0.0l, 0.0l);
+		 fmaxl(0.0l, 0.0l);
+		 fminl(0.0l, 0.0l);
+		 hypotl(0.0l, 0.0l);
+		 ilogbl(0.0l);
+		 lgammal(0.0l);
+		 #ifndef __APPLE__ /* see below */
+		 llrintl(0.0l);
+		 llroundl(0.0l);
+		 #endif
+		 log1pl(0.0l);
+		 log2l(0.0l);
+		 logbl(0.0l);
+		 lrintl(0.0l);
+		 lroundl(0.0l);
+		 nanl(0);
+		 nearbyintl(0.0l);
+		 nextafterl(0.0l, 0.0l);
+		 nexttoward(0.0, 0.0);
+		 nexttowardf(0.0f, 0.0f);
+		 nexttowardl(0.0l, 0.0l);
+		 remainderl(0.0l, 0.0l);
+		 remquol(0.0l, 0.0l, 0);
+		 rintl(0.0l);
+		 roundl(0.0l);
+		 scalblnl(0.0l, 0l);
+		 scalbnl(0.0l, 0);
+		 tgammal(0.0l);
+		 truncl(0.0l);
+		],
+		[glibcxx_cv_c99_math_long_double=yes],
+		[glibcxx_cv_c99_math_long_double=no])
+      ])
+    if test x"$glibcxx_cv_c99_math_long_double" = x"yes"; then
+      AC_DEFINE(_GLIBCXX_USE_C99_MATH_LONG_DOUBLE_FUNCS, 1,
+	        [Define if C99 long double math functions are available in <math.h>.])
+    fi
 
     case "${target_os}" in
       darwin*)

--- a/libstdc++-v3/config.h.in
+++ b/libstdc++-v3/config.h.in
@@ -922,6 +922,9 @@
    <tr1/cinttypes> in namespace std::tr1. */
 #undef _GLIBCXX_USE_C99_INTTYPES_WCHAR_T_TR1
 
+/* Define if C99 long double math functions are available in <math.h>. */
+#undef _GLIBCXX_USE_C99_MATH_LONG_DOUBLE_FUNCS
+
 /* Define if C99 functions or macros in <math.h> should be imported in
    <tr1/cmath> in namespace std::tr1. */
 #undef _GLIBCXX_USE_C99_MATH_TR1

--- a/libstdc++-v3/configure
+++ b/libstdc++-v3/configure
@@ -20001,111 +20001,74 @@ typedef double_t  my_double_t;
 		  typedef float_t   my_float_t;
 		  acosh(0.0);
 		  acoshf(0.0f);
-		  acoshl(0.0l);
 		  asinh(0.0);
 		  asinhf(0.0f);
-		  asinhl(0.0l);
 		  atanh(0.0);
 		  atanhf(0.0f);
-		  atanhl(0.0l);
 		  cbrt(0.0);
 		  cbrtf(0.0f);
-		  cbrtl(0.0l);
 		  copysign(0.0, 0.0);
 		  copysignf(0.0f, 0.0f);
-		  copysignl(0.0l, 0.0l);
 		  erf(0.0);
 		  erff(0.0f);
-		  erfl(0.0l);
 		  erfc(0.0);
 		  erfcf(0.0f);
-		  erfcl(0.0l);
 		  exp2(0.0);
 		  exp2f(0.0f);
-		  exp2l(0.0l);
 		  expm1(0.0);
 		  expm1f(0.0f);
-		  expm1l(0.0l);
 		  fdim(0.0, 0.0);
 		  fdimf(0.0f, 0.0f);
-		  fdiml(0.0l, 0.0l);
 		  fma(0.0, 0.0, 0.0);
 		  fmaf(0.0f, 0.0f, 0.0f);
-		  fmal(0.0l, 0.0l, 0.0l);
 		  fmax(0.0, 0.0);
 		  fmaxf(0.0f, 0.0f);
-		  fmaxl(0.0l, 0.0l);
 		  fmin(0.0, 0.0);
 		  fminf(0.0f, 0.0f);
-		  fminl(0.0l, 0.0l);
 		  hypot(0.0, 0.0);
 		  hypotf(0.0f, 0.0f);
-		  hypotl(0.0l, 0.0l);
 		  ilogb(0.0);
 		  ilogbf(0.0f);
-		  ilogbl(0.0l);
 		  lgamma(0.0);
 		  lgammaf(0.0f);
-		  lgammal(0.0l);
 		  #ifndef __APPLE__ /* see below */
 		  llrint(0.0);
 		  llrintf(0.0f);
-		  llrintl(0.0l);
 		  llround(0.0);
 		  llroundf(0.0f);
-		  llroundl(0.0l);
 		  #endif
 		  log1p(0.0);
 		  log1pf(0.0f);
-		  log1pl(0.0l);
 		  log2(0.0);
 		  log2f(0.0f);
-		  log2l(0.0l);
 		  logb(0.0);
 		  logbf(0.0f);
-		  logbl(0.0l);
 		  lrint(0.0);
 		  lrintf(0.0f);
-		  lrintl(0.0l);
 		  lround(0.0);
 		  lroundf(0.0f);
-		  lroundl(0.0l);
 		  nan(0);
 		  nanf(0);
-		  nanl(0);
 		  nearbyint(0.0);
 		  nearbyintf(0.0f);
-		  nearbyintl(0.0l);
 		  nextafter(0.0, 0.0);
 		  nextafterf(0.0f, 0.0f);
-		  nextafterl(0.0l, 0.0l);
-		  nexttoward(0.0, 0.0);
-		  nexttowardf(0.0f, 0.0f);
-		  nexttowardl(0.0l, 0.0l);
 		  remainder(0.0, 0.0);
 		  remainderf(0.0f, 0.0f);
-		  remainderl(0.0l, 0.0l);
 		  remquo(0.0, 0.0, 0);
 		  remquof(0.0f, 0.0f, 0);
-		  remquol(0.0l, 0.0l, 0);
 		  rint(0.0);
 		  rintf(0.0f);
-		  rintl(0.0l);
 		  round(0.0);
 		  roundf(0.0f);
-		  roundl(0.0l);
 		  scalbln(0.0, 0l);
 		  scalblnf(0.0f, 0l);
-		  scalblnl(0.0l, 0l);
 		  scalbn(0.0, 0);
 		  scalbnf(0.0f, 0);
-		  scalbnl(0.0l, 0);
 		  tgamma(0.0);
 		  tgammaf(0.0f);
-		  tgammal(0.0l);
 		  trunc(0.0);
 		  truncf(0.0f);
-		  truncl(0.0l);
 
   ;
   return 0;
@@ -20125,6 +20088,78 @@ $as_echo "$glibcxx_cv_c99_math_tr1" >&6; }
 
 $as_echo "#define _GLIBCXX_USE_C99_MATH_TR1 1" >>confdefs.h
 
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ISO C99 long double math functions in <math.h>" >&5
+$as_echo_n "checking for ISO C99 long double math functions in <math.h>... " >&6; }
+if ${glibcxx_cv_c99_math_long_double+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <math.h>
+int
+main ()
+{
+acoshl(0.0l);
+		 asinhl(0.0l);
+		 atanhl(0.0l);
+		 cbrtl(0.0l);
+		 copysignl(0.0l, 0.0l);
+		 erfl(0.0l);
+		 erfcl(0.0l);
+		 exp2l(0.0l);
+		 expm1l(0.0l);
+		 fdiml(0.0l, 0.0l);
+		 fmal(0.0l, 0.0l, 0.0l);
+		 fmaxl(0.0l, 0.0l);
+		 fminl(0.0l, 0.0l);
+		 hypotl(0.0l, 0.0l);
+		 ilogbl(0.0l);
+		 lgammal(0.0l);
+		 #ifndef __APPLE__ /* see below */
+		 llrintl(0.0l);
+		 llroundl(0.0l);
+		 #endif
+		 log1pl(0.0l);
+		 log2l(0.0l);
+		 logbl(0.0l);
+		 lrintl(0.0l);
+		 lroundl(0.0l);
+		 nanl(0);
+		 nearbyintl(0.0l);
+		 nextafterl(0.0l, 0.0l);
+		 nexttoward(0.0, 0.0);
+		 nexttowardf(0.0f, 0.0f);
+		 nexttowardl(0.0l, 0.0l);
+		 remainderl(0.0l, 0.0l);
+		 remquol(0.0l, 0.0l, 0);
+		 rintl(0.0l);
+		 roundl(0.0l);
+		 scalblnl(0.0l, 0l);
+		 scalbnl(0.0l, 0);
+		 tgammal(0.0l);
+		 truncl(0.0l);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  glibcxx_cv_c99_math_long_double=yes
+else
+  glibcxx_cv_c99_math_long_double=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $glibcxx_cv_c99_math_long_double" >&5
+$as_echo "$glibcxx_cv_c99_math_long_double" >&6; }
+    if test x"$glibcxx_cv_c99_math_long_double" = x"yes"; then
+
+$as_echo "#define _GLIBCXX_USE_C99_MATH_LONG_DOUBLE_FUNCS 1" >>confdefs.h
+
+    fi
 
     case "${target_os}" in
       darwin*)

--- a/libstdc++-v3/include/c_global/cmath
+++ b/libstdc++-v3/include/c_global/cmath
@@ -1068,145 +1068,149 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
   // functions
   using ::acosh;
   using ::acoshf;
-  using ::acoshl;
 
   using ::asinh;
   using ::asinhf;
-  using ::asinhl;
 
   using ::atanh;
   using ::atanhf;
-  using ::atanhl;
 
   using ::cbrt;
   using ::cbrtf;
-  using ::cbrtl;
 
   using ::copysign;
   using ::copysignf;
-  using ::copysignl;
 
   using ::erf;
   using ::erff;
-  using ::erfl;
 
   using ::erfc;
   using ::erfcf;
-  using ::erfcl;
 
   using ::exp2;
   using ::exp2f;
-  using ::exp2l;
 
   using ::expm1;
   using ::expm1f;
-  using ::expm1l;
 
   using ::fdim;
   using ::fdimf;
-  using ::fdiml;
 
   using ::fma;
   using ::fmaf;
-  using ::fmal;
 
   using ::fmax;
   using ::fmaxf;
-  using ::fmaxl;
 
   using ::fmin;
   using ::fminf;
-  using ::fminl;
 
   using ::hypot;
   using ::hypotf;
-  using ::hypotl;
 
   using ::ilogb;
   using ::ilogbf;
-  using ::ilogbl;
 
   using ::lgamma;
   using ::lgammaf;
-  using ::lgammal;
 
 #ifndef _GLIBCXX_NO_C99_ROUNDING_FUNCS
   using ::llrint;
   using ::llrintf;
-  using ::llrintl;
 
   using ::llround;
   using ::llroundf;
-  using ::llroundl;
 #endif
 
   using ::log1p;
   using ::log1pf;
-  using ::log1pl;
 
   using ::log2;
   using ::log2f;
-  using ::log2l;
 
   using ::logb;
   using ::logbf;
-  using ::logbl;
 
   using ::lrint;
   using ::lrintf;
-  using ::lrintl;
 
   using ::lround;
   using ::lroundf;
-  using ::lroundl;
 
   using ::nan;
   using ::nanf;
-  using ::nanl;
 
   using ::nearbyint;
   using ::nearbyintf;
-  using ::nearbyintl;
 
   using ::nextafter;
   using ::nextafterf;
-  using ::nextafterl;
-
-  using ::nexttoward;
-  using ::nexttowardf;
-  using ::nexttowardl;
 
   using ::remainder;
   using ::remainderf;
-  using ::remainderl;
 
   using ::remquo;
   using ::remquof;
-  using ::remquol;
 
   using ::rint;
   using ::rintf;
-  using ::rintl;
 
   using ::round;
   using ::roundf;
-  using ::roundl;
 
   using ::scalbln;
   using ::scalblnf;
-  using ::scalblnl;
 
   using ::scalbn;
   using ::scalbnf;
-  using ::scalbnl;
 
   using ::tgamma;
   using ::tgammaf;
-  using ::tgammal;
 
   using ::trunc;
   using ::truncf;
+
+#ifdef _GLIBCXX_USE_C99_MATH_LONG_DOUBLE_FUNCS
+  using ::acoshl;
+  using ::asinhl;
+  using ::atanhl;
+  using ::cbrtl;
+  using ::copysignl;
+  using ::erfl;
+  using ::erfcl;
+  using ::exp2l;
+  using ::expm1l;
+  using ::fdiml;
+  using ::fmal;
+  using ::fmaxl;
+  using ::fminl;
+  using ::hypotl;
+  using ::ilogbl;
+  using ::lgammal;
+#ifndef _GLIBCXX_NO_C99_ROUNDING_FUNCS
+  using ::llrintl;
+  using ::llroundl;
+#endif
+  using ::log1pl;
+  using ::log2l;
+  using ::logbl;
+  using ::lrintl;
+  using ::lroundl;
+  using ::nanl;
+  using ::nearbyintl;
+  using ::nextafterl;
+  using ::nexttoward;
+  using ::nexttowardf;
+  using ::nexttowardl;
+  using ::remainderl;
+  using ::remquol;
+  using ::rintl;
+  using ::roundl;
+  using ::scalblnl;
+  using ::scalbnl;
+  using ::tgammal;
   using ::truncl;
+#endif
 
   /// Additional overloads.
 #ifndef __CORRECT_ISO_CPP11_MATH_H_PROTO_FP

--- a/libstdc++-v3/include/tr1/cmath
+++ b/libstdc++-v3/include/tr1/cmath
@@ -160,143 +160,145 @@ namespace tr1
   // functions
   using ::acosh;
   using ::acoshf;
-  using ::acoshl;
 
   using ::asinh;
   using ::asinhf;
-  using ::asinhl;
 
   using ::atanh;
   using ::atanhf;
-  using ::atanhl;
 
   using ::cbrt;
   using ::cbrtf;
-  using ::cbrtl;
 
   using ::copysign;
   using ::copysignf;
-  using ::copysignl;
 
   using ::erf;
   using ::erff;
-  using ::erfl;
 
   using ::erfc;
   using ::erfcf;
-  using ::erfcl;
 
   using ::exp2;
   using ::exp2f;
-  using ::exp2l;
 
   using ::expm1;
   using ::expm1f;
-  using ::expm1l;
 
   using ::fdim;
   using ::fdimf;
-  using ::fdiml;
 
   using ::fma;
   using ::fmaf;
-  using ::fmal;
 
   using ::fmax;
   using ::fmaxf;
-  using ::fmaxl;
 
   using ::fmin;
   using ::fminf;
-  using ::fminl;
 
   using ::hypot;
   using ::hypotf;
-  using ::hypotl;
 
   using ::ilogb;
   using ::ilogbf;
-  using ::ilogbl;
 
   using ::lgamma;
   using ::lgammaf;
-  using ::lgammal;
 
   using ::llrint;
   using ::llrintf;
-  using ::llrintl;
 
   using ::llround;
   using ::llroundf;
-  using ::llroundl;
 
   using ::log1p;
   using ::log1pf;
-  using ::log1pl;
 
   using ::log2;
   using ::log2f;
-  using ::log2l;
 
   using ::logb;
   using ::logbf;
-  using ::logbl;
 
   using ::lrint;
   using ::lrintf;
-  using ::lrintl;
 
   using ::lround;
   using ::lroundf;
-  using ::lroundl;
 
   using ::nan;
   using ::nanf;
-  using ::nanl;
 
   using ::nearbyint;
   using ::nearbyintf;
-  using ::nearbyintl;
 
   using ::nextafter;
   using ::nextafterf;
-  using ::nextafterl;
-
-  using ::nexttoward;
-  using ::nexttowardf;
-  using ::nexttowardl;
 
   using ::remainder;
   using ::remainderf;
-  using ::remainderl;
 
   using ::remquo;
   using ::remquof;
-  using ::remquol;
 
   using ::rint;
   using ::rintf;
-  using ::rintl;
 
   using ::round;
   using ::roundf;
-  using ::roundl;
 
   using ::scalbln;
   using ::scalblnf;
-  using ::scalblnl;
 
   using ::scalbn;
   using ::scalbnf;
-  using ::scalbnl;
 
   using ::tgamma;
   using ::tgammaf;
-  using ::tgammal;
 
   using ::trunc;
   using ::truncf;
+
+#ifdef _GLIBCXX_USE_C99_MATH_LONG_DOUBLE_FUNCS
+  using ::acoshl;
+  using ::asinhl;
+  using ::atanhl;
+  using ::cbrtl;
+  using ::copysignl;
+  using ::erfl;
+  using ::erfcl;
+  using ::exp2l;
+  using ::expm1l;
+  using ::fdiml;
+  using ::fmal;
+  using ::fmaxl;
+  using ::fminl;
+  using ::hypotl;
+  using ::ilogbl;
+  using ::lgammal;
+  using ::llrintl;
+  using ::llroundl;
+  using ::log1pl;
+  using ::log2l;
+  using ::logbl;
+  using ::lrintl;
+  using ::lroundl;
+  using ::nanl;
+  using ::nearbyintl;
+  using ::nextafterl;
+  using ::nexttoward;
+  using ::nexttowardf;
+  using ::nexttowardl;
+  using ::remainderl;
+  using ::remquol;
+  using ::rintl;
+  using ::roundl;
+  using ::scalblnl;
+  using ::scalbnl;
+  using ::tgammal;
   using ::truncl;
+#endif
 
 #endif
 


### PR DESCRIPTION
```
libstdc++: Allow C99 long double math functions to be optional

The C99 math functions in the <cmath> header file are declared if and
only if the `_GLIBCXX_USE_C99_MATH_TR1` is defined, whose autoconf
check, `glibcxx_cv_c99_math_tr1`, requires all C99 math functions,
including the `long double` math functions, to be available.

Some C library implementations (for instance, newlib) may omit the C99
long double math function support when the type of `long double` is
different from the type of `double` and, in such cases, the <cmath>
header file ends up omitting the entirety of the C99 math functions.

This commit reworks the `glibcxx_cv_c99_math_tr1` check such that it
only tests the non-`long double` math functions, and adds a new check,
`glibcxx_cv_c99_math_long_double`, that tests the `long double` math
functions and defines `_GLIBCXX_USE_C99_MATH_LONG_DOUBLE_FUNCS` when
these functions are available; which is then used by the <cmath> header
file to conditionally import the C99 `long double` math functions,
effectively making the C99 long double math function support in <cmath>
an optional feature.

libstdc++-v3/ChangeLog:

	* acinclude.m4 (_GLIBCXX_USE_C99_MATH_LONG_DOUBLE_FUNCS): New macro.
	(_GLIBCXX_USE_C99_MATH_TR1): Remove long double function tests.
	* config.h.in: Regenerate.
	* configure: Regenerate.
	* include/c_global/cmath: Use _GLIBCXX_USE_C99_MATH_LONG_DOUBLE_FUNCS
	* include/tr1/cmath: Likewise.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Upstream-Status: Inappropriate [non-standard]
```