### PR TITLE
microblaze: Fix atomic boolean return value.

### DIFF
--- a/gcc/config/microblaze/microblaze.md
+++ b/gcc/config/microblaze/microblaze.md
@@ -43,6 +43,9 @@
   (UNSPEC_TLS           106)    ;; jump table
   (UNSPEC_SET_TEXT      107)    ;; set text start
   (UNSPEC_TEXT          108)    ;; data text relative
+  (UNSPECV_CAS_BOOL     201)    ;; compare and swap (bool)
+  (UNSPECV_CAS_VAL      202)    ;; compare and swap (val)
+  (UNSPECV_CAS_MEM      203)    ;; compare and swap (mem)
 ])
 
 (define_c_enum "unspec" [

--- a/gcc/config/microblaze/sync.md
+++ b/gcc/config/microblaze/sync.md
@@ -18,14 +18,19 @@
 ;; <http://www.gnu.org/licenses/>.
 
 (define_insn "atomic_compare_and_swapsi"
-  [(match_operand:SI 0 "register_operand" "=&d")	;; bool output
-   (match_operand:SI 1 "register_operand" "=&d")	;; val output
-   (match_operand:SI 2 "nonimmediate_operand" "+Q")	;; memory
-   (match_operand:SI 3 "register_operand" "d")		;; expected value
-   (match_operand:SI 4 "register_operand" "d")		;; desired value
-   (match_operand:SI 5 "const_int_operand" "")		;; is_weak
-   (match_operand:SI 6 "const_int_operand" "")		;; mod_s
-   (match_operand:SI 7 "const_int_operand" "")		;; mod_f
+  [(set (match_operand:SI 0 "register_operand" "=&d")		;; bool output
+        (unspec_volatile:SI
+          [(match_operand:SI 2 "nonimmediate_operand" "+Q")	;; memory
+           (match_operand:SI 3 "register_operand" "d")		;; expected value
+           (match_operand:SI 4 "register_operand" "d")]		;; desired value
+          UNSPECV_CAS_BOOL))
+   (set (match_operand:SI 1 "register_operand" "=&d")		;; val output
+        (unspec_volatile:SI [(const_int 0)] UNSPECV_CAS_VAL))
+   (set (match_dup 2)
+        (unspec_volatile:SI [(const_int 0)] UNSPECV_CAS_MEM))
+   (match_operand:SI 5 "const_int_operand" "")			;; is_weak
+   (match_operand:SI 6 "const_int_operand" "")			;; mod_s
+   (match_operand:SI 7 "const_int_operand" "")			;; mod_f
    (clobber (match_scratch:SI 8 "=&d"))]
   ""
   {

--- a/gcc/config/microblaze/sync.md
+++ b/gcc/config/microblaze/sync.md
@@ -29,15 +29,16 @@
    (clobber (match_scratch:SI 8 "=&d"))]
   ""
   {
-    output_asm_insn ("addc \tr0,r0,r0", operands);
+    output_asm_insn ("add  \t%0,r0,r0", operands);
     output_asm_insn ("lwx  \t%1,%y2,r0", operands);
     output_asm_insn ("addic\t%8,r0,0", operands);
     output_asm_insn ("bnei \t%8,.-8", operands);
-    output_asm_insn ("cmp  \t%0,%1,%3", operands);
-    output_asm_insn ("bnei \t%0,.+16", operands);
+    output_asm_insn ("cmp  \t%8,%1,%3", operands);
+    output_asm_insn ("bnei \t%8,.+20", operands);
     output_asm_insn ("swx  \t%4,%y2,r0", operands);
     output_asm_insn ("addic\t%8,r0,0", operands);
     output_asm_insn ("bnei \t%8,.-28", operands);
+    output_asm_insn ("addi \t%0,r0,1", operands);
     return "";
   }
 )


### PR DESCRIPTION
In atomic_compare_and_swapsi, fix boolean return value. Previously, it contained zero if successful and non-zero if unsuccessful.


Fixes Zephyr SDK Issue https://github.com/zephyrproject-rtos/sdk-ng/issues/646.
Patch file taken and applied from: https://github.com/Xilinx/meta-xilinx/blob/master/meta-microblaze/recipes-devtools/gcc/gcc-12/0009-Patch-microblaze-Fix-atomic-boolean-return-value.patch

CC @keith-packard 