### PR TITLE
libstdc++-v3: Add aligned_alloc to list of funcs in newlib targets

### DIFF
--- a/libstdc++-v3/configure
+++ b/libstdc++-v3/configure
@@ -29422,6 +29422,8 @@ else
 
     $as_echo "#define HAVE_MEMALIGN 1" >>confdefs.h
 
+    $as_echo "#define HAVE_ALIGNED_ALLOC 1" >>confdefs.h
+
   elif test "x$with_headers" != "xno"; then
 
 # Base decisions on target environment.

--- a/libstdc++-v3/configure.ac
+++ b/libstdc++-v3/configure.ac
@@ -357,6 +357,7 @@ else
 
     AC_DEFINE(HAVE_ICONV)
     AC_DEFINE(HAVE_MEMALIGN)
+    AC_DEFINE(HAVE_ALIGNED_ALLOC)
   elif test "x$with_headers" != "xno"; then
     GLIBCXX_CROSSCONFIG
   fi


### PR DESCRIPTION
Newlib supports the aligned_alloc function (as well as memalign), define HAVE_ALIGNED_ALLOC so that libstdc++ will prefer the C standard function over the obsolete and non-standard memalign function.