### PR TITLE
libgcc: implement gthreads in terms of C11 threads

### DIFF
--- a/config/gthr.m4
+++ b/config/gthr.m4
@@ -12,6 +12,7 @@ AC_DEFUN([GCC_AC_THREAD_HEADER],
 [
 case $1 in
     aix)	thread_header=config/rs6000/gthr-aix.h ;;
+    c11)	thread_header=gthr-c11.h ;;
     dce)	thread_header=config/pa/gthr-dce.h ;;
     gcn)	thread_header=config/gcn/gthr-gcn.h ;;
     lynx)	thread_header=config/gthr-lynx.h ;;

--- a/gcc/configure
+++ b/gcc/configure
@@ -12885,7 +12885,7 @@ case ${enable_threads} in
     # default
     target_thread_file='single'
     ;;
-  aix | dce | lynx | mipssde | posix | rtems | \
+  aix | c11 | dce | lynx | mipssde | posix | rtems | \
   single | tpf | vxworks | win32)
     target_thread_file=${enable_threads}
     ;;

--- a/gcc/configure.ac
+++ b/gcc/configure.ac
@@ -1994,7 +1994,7 @@ case ${enable_threads} in
     # default
     target_thread_file='single'
     ;;
-  aix | dce | lynx | mipssde | posix | rtems | \
+  aix | c11 | dce | lynx | mipssde | posix | rtems | \
   single | tpf | vxworks | win32)
     target_thread_file=${enable_threads}
     ;;

--- a/libgcc/configure
+++ b/libgcc/configure
@@ -5689,6 +5689,7 @@ tm_file="${tm_file_}"
 
 case $target_thread_file in
     aix)	thread_header=config/rs6000/gthr-aix.h ;;
+    c11)	thread_header=gthr-c11.h ;;
     dce)	thread_header=config/pa/gthr-dce.h ;;
     gcn)	thread_header=config/gcn/gthr-gcn.h ;;
     lynx)	thread_header=config/gthr-lynx.h ;;

--- a/libgcc/gthr-c11.h
+++ b/libgcc/gthr-c11.h
@@ -1,0 +1,258 @@
+/* Copyright (C) 1997-2023 Free Software Foundation, Inc.
+
+This file is part of GCC.
+
+GCC is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+Under Section 7 of GPL version 3, you are granted additional
+permissions described in the GCC Runtime Library Exception, version
+3.1, as published by the Free Software Foundation.
+
+You should have received a copy of the GNU General Public License and
+a copy of the GCC Runtime Library Exception along with this program;
+see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+<http://www.gnu.org/licenses/>.  */
+
+/* gthr.h API implementation in terms of ISO C11 threads.h */
+
+#ifndef _GLIBCXX_GCC_GTHR_C11_H
+#define _GLIBCXX_GCC_GTHR_C11_H
+
+#define __GTHREADS 1
+#define __GTHREADS_CXX0X 1
+#define __GTHREAD_ONCE_INIT ONCE_FLAG_INIT
+
+#define _GTHREAD_USE_MUTEX_TIMEDLOCK 1
+
+#undef __GTHREAD_MUTEX_INIT
+#define _GTHREAD_USE_MUTEX_INIT_FUNC 1
+#define __GTHREAD_MUTEX_INIT_FUNCTION __gthread_mutex_init_function
+
+#undef __GTHREAD_RECURSIVE_MUTEX_INIT
+#define _GTHREAD_USE_RECURSIVE_MUTEX_INIT_FUNC 1
+#define __GTHREAD_RECURSIVE_MUTEX_INIT_FUNCTION __gthread_recursive_mutex_init_function
+
+#define __GTHREAD_HAS_COND	1
+#undef __GTHREAD_COND_INIT
+#define _GTHREAD_USE_COND_INIT_FUNC 1
+#define __GTHREAD_COND_INIT_FUNCTION __gthread_cond_init_function
+
+#define _GLIBCXX_THREAD_ABI_COMPAT 1
+#define _GLIBCXX_HAS_GTHREADS 1
+#define _GLIBCXX_USE_THRD_SLEEP 1
+
+#include <threads.h>
+#include <time.h>
+
+typedef thrd_t __gthread_t;
+typedef tss_t __gthread_key_t;
+typedef once_flag __gthread_once_t;
+typedef mtx_t __gthread_mutex_t;
+typedef mtx_t __gthread_recursive_mutex_t;
+typedef cnd_t __gthread_cond_t;
+typedef struct timespec __gthread_time_t;
+
+static inline int __gthread_active_p(void)
+{
+  return 1;
+}
+
+static inline int
+__gthread_create (__gthread_t *__threadid, void *(*__func) (void*),
+		  void *__args)
+{
+  return thrd_create(__threadid, (thrd_start_t)__func, __args) != thrd_success;
+}
+
+static inline int
+__gthread_join (__gthread_t __threadid, void **__value_ptr)
+{
+  return thrd_join(__threadid, (int *)__value_ptr) != thrd_success;
+}
+
+static inline int
+__gthread_detach (__gthread_t __threadid)
+{
+  return thrd_detach(__threadid) != thrd_success;
+}
+
+static inline int
+__gthread_equal (__gthread_t __t1, __gthread_t __t2)
+{
+  return thrd_equal(__t1, __t2);
+}
+
+static inline __gthread_t
+__gthread_self (void)
+{
+  return thrd_current();
+}
+
+static inline int
+__gthread_yield (void)
+{
+  (void)thrd_yield();
+  return 0;
+}
+
+static inline int
+__gthread_once (__gthread_once_t *__once, void (*__func) (void))
+{
+  call_once(__once, __func);
+  return 0;
+}
+
+static inline int
+__gthread_key_create (__gthread_key_t *__key, void (*__dtor) (void *))
+{
+  return tss_create(__key, __dtor) != thrd_success;
+}
+
+static inline int
+__gthread_key_delete (__gthread_key_t __key)
+{
+  tss_delete(__key);
+  return 0;
+}
+
+static inline void *
+__gthread_getspecific (__gthread_key_t __key)
+{
+  return tss_get(__key);
+}
+
+static inline int
+__gthread_setspecific (__gthread_key_t __key, const void *__ptr)
+{
+  return tss_set(__key, (void *)__ptr) != thrd_success;
+}
+
+static inline void
+__gthread_mutex_init_function (__gthread_mutex_t *__mutex)
+{
+    (void)mtx_init(__mutex, mtx_plain);
+}
+
+static inline int
+__gthread_mutex_destroy (__gthread_mutex_t *__mutex)
+{
+    mtx_destroy(__mutex);
+    return 0;
+}
+
+static inline int
+__gthread_mutex_lock (__gthread_mutex_t *__mutex)
+{
+    return mtx_lock(__mutex) != thrd_success;
+}
+
+static inline int
+__gthread_mutex_trylock (__gthread_mutex_t *__mutex)
+{
+    return mtx_trylock(__mutex) != thrd_success;
+}
+
+static inline int
+__gthread_mutex_timedlock (__gthread_mutex_t *__mutex,
+			   const __gthread_time_t *__abs_timeout)
+{
+    return mtx_timedlock(__mutex, __abs_timeout) != thrd_success;
+}
+
+static inline int
+__gthread_mutex_unlock (__gthread_mutex_t *__mutex)
+{
+    return mtx_unlock(__mutex) != thrd_success;
+}
+
+static inline int
+__gthread_recursive_mutex_init_function (__gthread_recursive_mutex_t *__mutex)
+{
+    return mtx_init(__mutex, mtx_recursive) != thrd_success;
+}
+
+static inline int
+__gthread_recursive_mutex_lock (__gthread_recursive_mutex_t *__mutex)
+{
+  return mtx_lock(__mutex) != thrd_success;
+}
+
+static inline int
+__gthread_recursive_mutex_trylock (__gthread_recursive_mutex_t *__mutex)
+{
+  return mtx_trylock(__mutex) != thrd_success;
+}
+
+static inline int
+__gthread_recursive_mutex_timedlock (__gthread_recursive_mutex_t *__mutex,
+				     const __gthread_time_t *__abs_timeout)
+{
+  return __gthread_mutex_timedlock (__mutex, __abs_timeout);
+}
+
+static inline int
+__gthread_recursive_mutex_unlock (__gthread_recursive_mutex_t *__mutex)
+{
+  return __gthread_mutex_unlock (__mutex);
+}
+
+static inline int
+__gthread_recursive_mutex_destroy (__gthread_recursive_mutex_t *__mutex)
+{
+  return __gthread_mutex_destroy (__mutex);
+}
+
+static inline void
+__gthread_cond_init_function (__gthread_cond_t *__cond)
+{
+     (void)cnd_init(__cond);
+}
+
+static inline int
+__gthread_cond_broadcast (__gthread_cond_t *__cond)
+{
+  return cnd_broadcast(__cond) != thrd_success;
+}
+
+static inline int
+__gthread_cond_signal (__gthread_cond_t *__cond)
+{
+  return cnd_signal(__cond) != thrd_success;
+}
+
+static inline int
+__gthread_cond_wait (__gthread_cond_t *__cond, __gthread_mutex_t *__mutex)
+{
+  return cnd_wait(__cond, __mutex) != thrd_success;
+}
+
+static inline int
+__gthread_cond_timedwait (__gthread_cond_t *__cond, __gthread_mutex_t *__mutex,
+			  const __gthread_time_t *__abs_timeout)
+{
+  return cnd_timedwait(__cond, __mutex, __abs_timeout) != thrd_success;
+}
+
+static inline int
+__gthread_cond_wait_recursive (__gthread_cond_t *__cond,
+			       __gthread_recursive_mutex_t *__mutex)
+{
+  return __gthread_cond_wait (__cond, __mutex);
+}
+
+static inline int
+__gthread_cond_destroy (__gthread_cond_t* __cond)
+{
+  cnd_destroy(__cond);
+  return 0;
+}
+
+#endif /* ! _GLIBCXX_GCC_GTHR_C11_H */

--- a/libstdc++-v3/configure
+++ b/libstdc++-v3/configure
@@ -20493,7 +20493,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 if test "${enable_libstdcxx_time+set}" = set; then :
   enableval=$enable_libstdcxx_time;
       case "$enableval" in
-       yes|no|rt) ;;
+       yes|no|rt|c11) ;;
        *) as_fn_error $? "Unknown argument to enable/disable libstdcxx-time" "$LINENO" 5 ;;
 	  	        esac
 
@@ -20518,6 +20518,21 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
   ac_has_clock_realtime=no
   ac_has_nanosleep=no
   ac_has_sched_yield=no
+  ac_has_thrd_sleep=no
+
+    for ac_header in threads.h
+do :
+  ac_fn_cxx_check_header_mongrel "$LINENO" "threads.h" "ac_cv_header_threads_h" "$ac_includes_default"
+if test "x$ac_cv_header_threads_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_THREADS_H 1
+_ACEOF
+  ac_has_threads_h=yes
+else
+  ac_has_threads_h=no
+fi
+
+done
 
   if test x"$enable_libstdcxx_time" = x"auto"; then
 
@@ -20626,6 +20641,13 @@ fi
         ac_has_nanosleep=yes
         ac_has_sched_yield=yes
     esac
+
+  elif test x"$enable_libstdcxx_time" = x"c11"; then
+
+    # workaround for the error below until ac_cv_func_thrd_sleep is available when cross-compiling
+    # checking for library containing thrd_sleep...
+    # configure: error: Link tests are not allowed after GCC_NO_EXECUTABLES.
+    ac_has_thrd_sleep=yes
 
   elif test x"$enable_libstdcxx_time" != x"no"; then
 
@@ -20748,6 +20770,11 @@ if test "$ac_res" != no; then :
 
 fi
 
+    elif test x"$enable_libstdcxx_time" = x"c11"; then
+      ac_fn_cxx_check_func "$LINENO" "thrd_sleep" "ac_cv_func_thrd_sleep"
+if test "x$ac_cv_func_thrd_sleep" = xyes; then :
+
+fi
     else
       ac_fn_cxx_check_func "$LINENO" "clock_gettime" "ac_cv_func_clock_gettime"
 if test "x$ac_cv_func_clock_gettime" = xyes; then :
@@ -21058,6 +21085,10 @@ $as_echo "#define _GLIBCXX_USE_SCHED_YIELD 1" >>confdefs.h
 
 $as_echo "#define _GLIBCXX_USE_NANOSLEEP 1" >>confdefs.h
 
+  elif test x"$ac_has_thrd_sleep" = x"yes"; then
+
+$as_echo "#define _GLIBCXX_USE_THRD_SLEEP 1" >>confdefs.h
+
   else
       { $as_echo "$as_me:${as_lineno-$LINENO}: checking for sleep" >&5
 $as_echo_n "checking for sleep... " >&6; }
@@ -21114,7 +21145,7 @@ $as_echo "#define HAVE_USLEEP 1" >>confdefs.h
 $as_echo "$ac_has_usleep" >&6; }
   fi
 
-  if test x"$ac_has_nanosleep$ac_has_sleep" = x"nono"; then
+  if test x"$ac_has_nanosleep$ac_has_sleep$ac_has_thrd_sleep" = x"nonono"; then
       ac_no_sleep=yes
       { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Sleep" >&5
 $as_echo_n "checking for Sleep... " >&6; }

--- a/libstdc++-v3/configure
+++ b/libstdc++-v3/configure
@@ -15764,6 +15764,7 @@ $as_echo "$target_thread_file" >&6; }
 
 case $target_thread_file in
     aix)	thread_header=config/rs6000/gthr-aix.h ;;
+    c11)	thread_header=gthr-c11.h ;;
     dce)	thread_header=config/pa/gthr-dce.h ;;
     gcn)	thread_header=config/gcn/gthr-gcn.h ;;
     lynx)	thread_header=config/gthr-lynx.h ;;

--- a/libstdc++-v3/include/Makefile.am
+++ b/libstdc++-v3/include/Makefile.am
@@ -1012,6 +1012,7 @@ thread_host_headers = \
 	${host_builddir}/gthr.h \
 	${host_builddir}/gthr-single.h \
 	${host_builddir}/gthr-posix.h \
+	${host_builddir}/gthr-c11.h \
 	${host_builddir}/gthr-default.h
 
 
@@ -1381,6 +1382,12 @@ ${host_builddir}/gthr-posix.h: ${toplevel_srcdir}/libgcc/gthr-posix.h \
 	    -e 's/\(GCC${uppercase}*_H\)/_GLIBCXX_\1/g' \
 	    -e 's/SUPPORTS_WEAK/__GXX_WEAK__/g' \
 	    -e 's/\(${uppercase}*USE_WEAK\)/_GLIBCXX_\1/g' \
+	    < $< > $@
+
+${host_builddir}/gthr-c11.h: ${toplevel_srcdir}/libgcc/gthr-c11.h \
+				  stamp-${host_alias}
+	sed -e 's/\(UNUSED\)/_GLIBCXX_\1/g' \
+	    -e 's/\(GCC${uppercase}*_H\)/_GLIBCXX_\1/g' \
 	    < $< > $@
 
 ${host_builddir}/gthr-default.h: ${toplevel_srcdir}/libgcc/${thread_header} \

--- a/libstdc++-v3/include/Makefile.in
+++ b/libstdc++-v3/include/Makefile.in
@@ -1363,6 +1363,7 @@ thread_host_headers = \
 	${host_builddir}/gthr.h \
 	${host_builddir}/gthr-single.h \
 	${host_builddir}/gthr-posix.h \
+	${host_builddir}/gthr-c11.h \
 	${host_builddir}/gthr-default.h
 
 pch1_source = ${glibcxx_srcdir}/include/precompiled/stdc++.h
@@ -1867,6 +1868,14 @@ ${host_builddir}/gthr-single.h: ${toplevel_srcdir}/libgcc/gthr-single.h \
 	    < $< > $@
 
 ${host_builddir}/gthr-posix.h: ${toplevel_srcdir}/libgcc/gthr-posix.h \
+				   stamp-${host_alias}
+	sed -e 's/\(UNUSED\)/_GLIBCXX_\1/g' \
+	    -e 's/\(GCC${uppercase}*_H\)/_GLIBCXX_\1/g' \
+	    -e 's/SUPPORTS_WEAK/__GXX_WEAK__/g' \
+	    -e 's/\(${uppercase}*USE_WEAK\)/_GLIBCXX_\1/g' \
+	    < $< > $@
+
+${host_builddir}/gthr-c11.h: ${toplevel_srcdir}/libgcc/gthr-c11.h \
 				   stamp-${host_alias}
 	sed -e 's/\(UNUSED\)/_GLIBCXX_\1/g' \
 	    -e 's/\(GCC${uppercase}*_H\)/_GLIBCXX_\1/g' \

--- a/libstdc++-v3/include/bits/std_thread.h
+++ b/libstdc++-v3/include/bits/std_thread.h
@@ -41,6 +41,7 @@
 #include <bits/invoke.h>	// std::__invoke
 #include <bits/refwrap.h>       // not required, but helpful to users
 #include <bits/unique_ptr.h>	// std::unique_ptr
+#include <bits/shared_ptr.h>	// std::shared_ptr
 
 #ifdef _GLIBCXX_HAS_GTHREADS
 # include <bits/gthr.h>

--- a/libstdc++-v3/include/bits/this_thread_sleep.h
+++ b/libstdc++-v3/include/bits/this_thread_sleep.h
@@ -40,6 +40,10 @@
 # include <time.h>  // nanosleep
 #endif
 
+#ifdef _GLIBCXX_USE_THRD_SLEEP
+#include <threads.h>
+#endif
+
 namespace std _GLIBCXX_VISIBILITY(default)
 {
 _GLIBCXX_BEGIN_NAMESPACE_VERSION
@@ -57,7 +61,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
   {
 #ifndef _GLIBCXX_NO_SLEEP
 
-#ifndef _GLIBCXX_USE_NANOSLEEP
+#if !(defined(_GLIBCXX_USE_NANOSLEEP) || defined(_GLIBCXX_USE_THRD_SLEEP))
     void
     __sleep_for(chrono::seconds, chrono::nanoseconds);
 #endif
@@ -79,6 +83,13 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	  };
 	while (::nanosleep(&__ts, &__ts) == -1 && errno == EINTR)
 	  { }
+#elif defined(_GLIBCXX_USE_THRD_SLEEP)
+	struct ::timespec __ts =
+	  {
+	    static_cast<std::time_t>(__s.count()),
+	    static_cast<long>(__ns.count())
+	  };
+  ::thrd_sleep(&__ts, &__ts);
 #else
 	__sleep_for(__s, __ns);
 #endif

--- a/libstdc++-v3/src/c++11/thread.cc
+++ b/libstdc++-v3/src/c++11/thread.cc
@@ -214,6 +214,13 @@ namespace this_thread
       };
     while (::nanosleep(&__ts, &__ts) == -1 && errno == EINTR)
       { }
+#elif defined(_GLIBCXX_HAVE_THRD_SLEEP)
+    struct ::timespec __ts =
+      {
+	static_cast<std::time_t>(__s.count()),
+	static_cast<long>(__ns.count())
+      };
+    ::thrd_sleep(&__ts, &__ts);
 #elif defined(_GLIBCXX_HAVE_SLEEP)
     const auto target = chrono::steady_clock::now() + __s + __ns;
     while (true)


### PR DESCRIPTION
Provide the `gthr.h` API implementation in terms of the ISO C11 threads API.

Add support for `--enable-libstdcxx-time=c11` via the ISO C11 `threads.h` API function `thrd_sleep()`.