### PR TITLE
libc++ 17 compatibility fixes

### DIFF
--- a/gcc/system.h
+++ b/gcc/system.h
@@ -194,27 +194,8 @@ extern int fprintf_unlocked (FILE *, const char *, ...);
 #undef fread_unlocked
 #undef fwrite_unlocked
 
-/* Include <string> before "safe-ctype.h" to avoid GCC poisoning
-   the ctype macros through safe-ctype.h */
-
-#ifdef __cplusplus
-#ifdef INCLUDE_STRING
-# include <string>
-#endif
-#endif
-
-/* There are an extraordinary number of issues with <ctype.h>.
-   The last straw is that it varies with the locale.  Use libiberty's
-   replacement instead.  */
-#include "safe-ctype.h"
-
-#include <sys/types.h>
-
-#include <errno.h>
-
-#if !defined (errno) && defined (HAVE_DECL_ERRNO) && !HAVE_DECL_ERRNO
-extern int errno;
-#endif
+/* Include C++ standard headers before "safe-ctype.h" to avoid GCC
+   poisoning the ctype macros through safe-ctype.h */
 
 #ifdef __cplusplus
 #if defined (INCLUDE_ALGORITHM) || !defined (HAVE_SWAP_IN_UTILITY)
@@ -228,6 +209,9 @@ extern int errno;
 #endif
 #ifdef INCLUDE_SET
 # include <set>
+#endif
+#ifdef INCLUDE_STRING
+# include <string>
 #endif
 #ifdef INCLUDE_VECTOR
 # include <vector>
@@ -243,6 +227,19 @@ extern int errno;
 # include <new>
 # include <utility>
 # include <type_traits>
+#endif
+
+/* There are an extraordinary number of issues with <ctype.h>.
+   The last straw is that it varies with the locale.  Use libiberty's
+   replacement instead.  */
+#include "safe-ctype.h"
+
+#include <sys/types.h>
+
+#include <errno.h>
+
+#if !defined (errno) && defined (HAVE_DECL_ERRNO) && !HAVE_DECL_ERRNO
+extern int errno;
 #endif
 
 /* Some of glibc's string inlines cause warnings.  Plus we'd rather

--- a/libcc1/libcc1plugin.cc
+++ b/libcc1/libcc1plugin.cc
@@ -32,6 +32,7 @@
 #undef PACKAGE_VERSION
 
 #define INCLUDE_MEMORY
+#define INCLUDE_VECTOR
 #include "gcc-plugin.h"
 #include "system.h"
 #include "coretypes.h"
@@ -68,8 +69,6 @@
 #include "rpc.hh"
 #include "gcc-c-interface.h"
 #include "context.hh"
-
-#include <vector>
 
 using namespace cc1_plugin;
 

--- a/libcc1/libcp1plugin.cc
+++ b/libcc1/libcp1plugin.cc
@@ -33,6 +33,7 @@
 #undef PACKAGE_VERSION
 
 #define INCLUDE_MEMORY
+#define INCLUDE_VECTOR
 #include "gcc-plugin.h"
 #include "system.h"
 #include "coretypes.h"
@@ -70,8 +71,6 @@
 #include "marshall-cp.hh"
 #include "rpc.hh"
 #include "context.hh"
-
-#include <vector>
 
 using namespace cc1_plugin;
 


### PR DESCRIPTION
This series includes the patches to fix the ctype macro poisoning issues when building with libc++ >= 17 (see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111632 for more details).

In terms of Zephyr SDK, this is for building GCC with Xcode 15.3 on macOS.