### PR TITLE
microblaze: Fix -Os right shift optimization is allowed into delay slot

### DIFF
--- a/gcc/config/microblaze/microblaze.md
+++ b/gcc/config/microblaze/microblaze.md
@@ -2286,7 +2286,7 @@ else
     output_asm_insn ("bneid\t%3,.-4", operands);
     return "sra\t%0,%0";
   }
-  [(set_attr "type"    "arith")
+  [(set_attr "type"    "multi")
   (set_attr "mode"    "SI")
   (set_attr "length"  "20")]
 )


### PR DESCRIPTION
During picolibc testing, it's found that `-Os` produces assembly code that compiler
squeezes into a single delay slot. Thus, only the first instruction emitted by this optimization is run and the rest is skipped.
Optimization is generated by
```
  [(set (match_operand:SI 0 "register_operand" "=&d")
       (ashiftrt:SI (match_operand:SI 1 "register_operand"  "d")
                   (match_operand:SI 2 "immediate_operand" "I")))]
  "(INTVAL (operands[2]) > 5 && optimize_size)"
  {
    operands[3] = gen_rtx_REG (SImode, MB_ABI_ASM_TEMP_REGNUM);

    output_asm_insn ("ori\t%3,r0,%2", operands);
    if (REGNO (operands[0]) != REGNO (operands[1]))
        output_asm_insn ("addk\t%0,%1,r0", operands);

    output_asm_insn ("addik\t%3,%3,-1", operands);
    output_asm_insn ("bneid\t%3,.-4", operands);
    return "sra\t%0,%0";
  }
  [(set_attr "type"    "arith")
  (set_attr "mode"    "SI")
  (set_attr "length"  "20")]
```
But `arith` type is NOT disallowed from going into delay slot (see below):
https://github.com/zephyrproject-rtos/gcc/blob/428d8d7b0542338244ca41ac06a5f3fa4f29bb6d/gcc/config/microblaze/microblaze.md?plain=1#L466
"Optimized" code is between [191b8-191c8]
```
   191a8:	bc830194 	bgti	r3, 404		// 1933c
    if (subnormal_y) { /* subnormal y */
   191ac:	b0007ff0 	imm	32752
   191b0:	a47c0000 	andi	r3, r28, 0
   191b4:	be2301ec 	bneid	r3, 492		// 193a0
   191b8:	a2400014 	ori	r18, r0, 20
   191bc:	131e0000 	addk	r24, r30, r0
   191c0:	3252ffff 	addik	r18, r18, -1
   191c4:	be32fffc 	bneid	r18, -4		// 191c0
   191c8:	93180001 	sra	r24, r24
...
        iy = (hy >> 20) - 1023;
   193a0:	b810fe40 	brid	-448		// 191e0
   193a4:	3318fc01 	addik	r24, r24, -1023
```
where `operands` are:
```
operands[0] = r24
operands[1] = r29
operands[2] = 20
operands[3] = r18
```
As a result, this code returns a `iy` (`r24`) value of (whatever was in r24) - 1023`

The fix is simple. I've redeclared this size-optimization as `multi` which is
1. Not delay-slot allowed
2. Also the same type for other shift optimizations (they're left shift optimizations)
  1.  https://github.com/zephyrproject-rtos/gcc/blob/428d8d7b0542338244ca41ac06a5f3fa4f29bb6d/gcc/config/microblaze/microblaze.md?plain=1#L2070
  2. https://github.com/zephyrproject-rtos/gcc/blob/428d8d7b0542338244ca41ac06a5f3fa4f29bb6d/gcc/config/microblaze/microblaze.md?plain=1#L2483

For context, non-size-optimized code is `N` copies of:
```
sra	r24, r24 /* arithmetic 1-bit shift r24 and put result into r24 */
```
And as per the above optimization rule, if `N <= 5` we'll still get 5 copies of `sra` instruction.

Currently under test via https://github.com/zephyrproject-rtos/sdk-ng/pull/647
