### PR TITLE
Add support for --enable-multilib-space option

### DIFF
--- a/config-ml.in
+++ b/config-ml.in
@@ -175,7 +175,7 @@ eval scan_arguments "${ac_configure_args}"
 unset scan_arguments
 
 # Only do this if --enable-multilib.
-if [ "${enable_multilib}" = yes ]; then
+if [ "${enable_multilib}" = yes -o "${enable_multilib_space}" = yes ]; then
 
 # Compute whether this is the library's top level directory
 # (ie: not a multilib subdirectory, and not a subdirectory like newlib/src).

--- a/gcc/Makefile.in
+++ b/gcc/Makefile.in
@@ -2179,25 +2179,47 @@ libgcc.mvars: config.status Makefile specs xgcc$(exeext)
 
 	mv tmp-libgcc.mvars libgcc.mvars
 
+ifeq (@enable_multilib_space@,yes)
+MULTILIB_OPTIONS	+= Os
+MULTILIB_DIRNAMES	+= space
+MULTILIB_MATCHES	+= Os=Oz
+
+MULTILIB_OSDIRNAMES_SPACE = $(MULTILIB_OSDIRNAMES)\
+	$(if $(findstring =,$(MULTILIB_OSDIRNAMES)),\
+	  $(foreach OSD,$(MULTILIB_OSDIRNAMES),$(subst =,/Os=,$(OSD))/space),\
+	  $(if $(MULTILIB_OSDIRNAMES),space,))
+MULTILIB_REQUIRED_SPACE = $(if $(MULTILIB_REQUIRED),Os $(foreach REQ, $(MULTILIB_REQUIRED), $(REQ) $(REQ)/Os),)
+MULTILIB_EXCEPTIONS_SPACE = $(foreach EXC, $(MULTILIB_EXCEPTIONS), $(EXC) $(EXC)/Os)
+MULTILIB_REUSE_SPACE = $(foreach REU, $(MULTILIB_REUSE), $(REU) $(subst =,/Os=,$(REU))/Os)
+MULTILIB_ENABLE = yes
+else
+MULTILIB_OSDIRNAMES_SPACE = $(MULTILIB_OSDIRNAMES)
+MULTILIB_REQUIRED_SPACE = $(MULTILIB_REQUIRED)
+MULTILIB_EXCEPTIONS_SPACE = $(MULTILIB_EXCEPTIONS)
+MULTILIB_REUSE_SPACE = $(MULTILIB_REUSE)
+MULTILIB_ENABLE = @multilib@
+endif
+
 # Use the genmultilib shell script to generate the information the gcc
 # driver program needs to select the library directory based on the
 # switches.
 multilib.h: s-mlib; @true
 s-mlib: $(srcdir)/genmultilib Makefile
 	if test @enable_multilib@ = yes \
+           || test @enable_multilib_space@ = yes \
 	   || test -n "$(MULTILIB_OSDIRNAMES)"; then \
 	  $(SHELL) $(srcdir)/genmultilib \
 	    "$(MULTILIB_OPTIONS)" \
 	    "$(MULTILIB_DIRNAMES)" \
 	    "$(MULTILIB_MATCHES)" \
-	    "$(MULTILIB_EXCEPTIONS)" \
+	    "$(MULTILIB_EXCEPTIONS_SPACE)" \
 	    "$(MULTILIB_EXTRA_OPTS)" \
 	    "$(MULTILIB_EXCLUSIONS)" \
-	    "$(MULTILIB_OSDIRNAMES)" \
-	    "$(MULTILIB_REQUIRED)" \
+	    "$(MULTILIB_OSDIRNAMES_SPACE)" \
+	    "$(MULTILIB_REQUIRED_SPACE)" \
 	    "$(if $(MULTILIB_OSDIRNAMES),,$(MULTIARCH_DIRNAME))" \
-	    "$(MULTILIB_REUSE)" \
-	    "@enable_multilib@" \
+	    "$(MULTILIB_REUSE_SPACE)" \
+	    "$(MULTILIB_ENABLE)" \
 	    > tmp-mlib.h; \
 	else \
 	  $(SHELL) $(srcdir)/genmultilib '' '' '' '' '' '' '' '' \

--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -4517,6 +4517,7 @@ case "${target}" in
 					case ${arm_multilib} in
 					aprofile|rmprofile)
 						tmake_profile_file="arm/t-multilib"
+						tm_mlib_file="arm/arm-mlib.h"
 						;;
 					@*)
 						ml=`echo "X$arm_multilib" | sed '1s,^X@,,'`
@@ -4555,6 +4556,7 @@ case "${target}" in
 				# through to the multilib selector
 				with_float="soft"
 				tmake_file="${tmake_file} ${tmake_profile_file}"
+				tm_file="$tm_file $tm_mlib_file"
 				TM_MULTILIB_CONFIG="$with_multilib_list"
 			fi
 		fi

--- a/gcc/config/arm/arm-mlib.h
+++ b/gcc/config/arm/arm-mlib.h
@@ -1,0 +1,22 @@
+/* Arm multilib default option include file.
+
+   Copyright (C) 2023-2024 Free Software Foundation, Inc.
+   Contributed by Arm.
+
+   This file is part of GCC.
+
+   GCC is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published
+   by the Free Software Foundation; either version 3, or (at your
+   option) any later version.
+
+   GCC is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+   or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+   License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with GCC; see the file COPYING3.  If not see
+   <http://www.gnu.org/licenses/>.  */
+
+#define MULTILIB_DEFAULTS { "marm", "mfloat-abi=soft", }

--- a/gcc/configure
+++ b/gcc/configure
@@ -838,6 +838,7 @@ enable_decimal_float
 with_float
 with_cpu
 enable_multiarch
+enable_multilib_space
 enable_multilib
 coverage_flags
 valgrind_command
@@ -960,6 +961,7 @@ enable_coverage
 enable_gather_detailed_mem_stats
 enable_valgrind_annotations
 enable_multilib
+enable_multilib_space
 enable_multiarch
 with_stack_clash_protection_guard_size
 enable___cxa_atexit
@@ -1691,6 +1693,7 @@ Optional Features:
   --enable-valgrind-annotations
                           enable valgrind runtime interaction
   --enable-multilib       enable library support for multiple ABIs
+  --enable-multilib-space enable extra -Os variant for every multilib ABI
   --enable-multiarch      enable support for multiarch paths
   --enable-__cxa_atexit   enable __cxa_atexit for C++
   --enable-decimal-float={no,yes,bid,dpd}
@@ -7812,6 +7815,16 @@ if test "${enable_multilib+set}" = set; then :
   enableval=$enable_multilib;
 else
   enable_multilib=yes
+fi
+
+
+
+# Determine whether or not -Os multilibs are enabled.
+# Check whether --enable-multilib-space was given.
+if test "${enable_multilib_space+set}" = set; then :
+  enableval=$enable_multilib_space;
+else
+  enable_multilib_space=no
 fi
 
 

--- a/gcc/configure.ac
+++ b/gcc/configure.ac
@@ -868,6 +868,13 @@ AC_ARG_ENABLE(multilib,
 [], [enable_multilib=yes])
 AC_SUBST(enable_multilib)
 
+# Determine whether or not -Os multilibs are enabled.
+AC_ARG_ENABLE(multilib-space,
+[AS_HELP_STRING([--enable-multilib-space],
+		[enable extra -Os variant for every multilib ABI])],
+[], [enable_multilib_space=no])
+AC_SUBST(enable_multilib_space)
+
 # Determine whether or not multiarch is enabled.
 AC_ARG_ENABLE(multiarch,
 [AS_HELP_STRING([--enable-multiarch],

--- a/gcc/doc/install.texi
+++ b/gcc/doc/install.texi
@@ -1175,6 +1175,18 @@ for aarch64*-*-*, arm*-*-*, loongarch64-*-*, riscv*-*-*, sh*-*-* and
 x86-64-*-linux*.  The accepted values and meaning for each target is given
 below.
 
+@item --enable-multilib-space
+Double the set of target libraries built by building two versions of
+each specified by the options above, one using @option{-O2 }and
+another using @option{-Os}. During linking, the @option{-O2} variant
+will be selected by default. Select the @option{-Os} variant by
+including @option{-Os} or @option{-Oz} in the linker command
+line. Note: because multilib selection only looks for the presence of
+compiler flags (unlike options controlling the compiler optimization
+level), a subsequent optimization flag other than @option{-Os} or or
+@option{-Oz} will not switch back to the @option{-O2} library
+versions.
+
 @table @code
 @item aarch64*-*-*
 @var{list} is a comma separated list of @code{ilp32}, and @code{lp64}

--- a/libgcc/Makefile.in
+++ b/libgcc/Makefile.in
@@ -293,16 +293,20 @@ override CFLAGS := $(filter-out -fprofile-generate -fprofile-use,$(CFLAGS))
 # CFLAGS first is not perfect; normally setting CFLAGS should override any
 # options in LIBGCC2_CFLAGS.  But LIBGCC2_CFLAGS may contain -g0, and CFLAGS
 # will usually contain -g, so for the moment CFLAGS goes first.  We must
-# include CFLAGS - that's where multilib options live.
+# include CFLAGS - that's where multilib options live. If CC or CFLAGS
+# specify -Os or -Oz, we want that to override our local options as that
+# could be a multilib flag.
 INTERNAL_CFLAGS = $(CFLAGS) $(LIBGCC2_CFLAGS) $(HOST_LIBGCC2_CFLAGS) \
-		  $(INCLUDES) @set_have_cc_tls@ @set_use_emutls@
+		  $(INCLUDES) @set_have_cc_tls@ @set_use_emutls@ \
+		  $(filter -Os -Oz,$(CC) $(CFLAGS))
 
 # Options to use when compiling crtbegin/end.
 CRTSTUFF_CFLAGS = -O2 $(GCC_CFLAGS) $(INCLUDES) $(MULTILIB_CFLAGS) -g0 \
   $(NO_PIE_CFLAGS) -finhibit-size-directive -fno-inline -fno-exceptions \
   -fno-zero-initialized-in-bss -fno-toplevel-reorder -fno-tree-vectorize \
   -fbuilding-libgcc -fno-stack-protector $(FORCE_EXPLICIT_EH_REGISTRY) \
-  $(INHIBIT_LIBC_CFLAGS) $(USE_TM_CLONE_REGISTRY)
+  $(INHIBIT_LIBC_CFLAGS) $(USE_TM_CLONE_REGISTRY) \
+  $(filter -Os -Oz,$(CC) $(CFLAGS))
 
 # Extra flags to use when compiling crt{begin,end}.o.
 CRTSTUFF_T_CFLAGS =


### PR DESCRIPTION
The --enable-multilib-space option creates -O2 and -Os variants for each multilib variant. At link time, applications select the space optimized versions by including -Os in their link command line.