### PR TITLE
[rx] Support RX GCC Zephyr build

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -3206,7 +3206,14 @@ rl78-*-elf*)
 	;;
 rx-*-elf*)
 	tm_file="dbxelf.h elfos.h newlib-stdint.h ${tm_file}"
-	tmake_file="${tmake_file} rx/t-rx"
+	case ${target} in
+	    rx-zephyr*)
+		tmake_file="${tmake_file} rx/t-zephyr"
+		;;
+	    *)
+	        tmake_file="${tmake_file} rx/t-rx"
+		;;
+	esac
 	extra_options="${extra_options} rx/elf.opt"
 	;;
 rx-*-linux*)

--- a/gcc/config/rx/rx.md
+++ b/gcc/config/rx/rx.md
@@ -2590,7 +2590,9 @@
    (clobber (reg:SI 3))
    (clobber (reg:CC CC_REG))]
   "rx_allow_string_insns"
-  "scmpu		; Perform the string comparison
+  "setpsw  z		; Set flags in case len is zero
+   setpsw  c
+   scmpu		; Perform the string comparison
    mov     #-1, %0      ; Set up -1 result (which cannot be created
                         ; by the SC insn)
    bnc	   ?+		; If Carry is not set skip over

--- a/gcc/config/rx/t-zephyr
+++ b/gcc/config/rx/t-zephyr
@@ -1,0 +1,37 @@
+# Makefile fragment for building GCC for the Renesas RX target.
+# Copyright (C) 2008-2022 Free Software Foundation, Inc.
+# Contributed by Red Hat.
+#
+# This file is part of GCC.
+#
+# GCC is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published
+# by the Free Software Foundation; either version 3, or (at your
+# option) any later version.
+#
+# GCC is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See
+# the GNU General Public License for more details.
+#
+# You should have received a copy of the  GNU General Public
+# License along with GCC; see the file COPYING3.  If not see
+# <http://www.gnu.org/licenses/>.
+
+# Enable multilibs:
+
+MULTILIB_OPTIONS    = m64bit-doubles  nofpu        mbig-endian-data  mpid
+MULTILIB_DIRNAMES   =  64-bit-double  no-fpu-libs   big-endian-data   pid
+
+# If necessary uncomment the next two lines to generate multilibs
+# using the old, broken, ABI.
+# MULTILIB_OPTIONS    += mgcc-abi
+# MULTILIB_DIRNAMES   +=  gcc-abi
+
+MULTILIB_OPTIONS   += mno-allow-string-insns
+MULTILIB_DIRNAMES  += no-strings
+
+MULTILIB_MATCHES    = nofpu=mnofpu  nofpu=mcpu?rx200  nofpu=mcpu?rx100
+
+MULTILIB_EXCEPTIONS =
+MULTILIB_EXTRA_OPTS =


### PR DESCRIPTION
This commit enables rx-zephyr-elf-* build for RX architecture on Zephyr SDK
https://github.com/zephyrproject-rtos/zephyr/issues/81313
The change is only adding new t-zephyr build based on t-rx, for Zephyr SDK build.