### PR TITLE
libstdc++-v3: Use stdio in random.cc when using cstdio=stdio_pure

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -3206,7 +3206,14 @@ rl78-*-elf*)
 	;;
 rx-*-elf*)
 	tm_file="dbxelf.h elfos.h newlib-stdint.h ${tm_file}"
-	tmake_file="${tmake_file} rx/t-rx"
+	case ${target} in
+	    rx-zephyr*)
+		tmake_file="${tmake_file} rx/t-zephyr"
+		;;
+	    *)
+	        tmake_file="${tmake_file} rx/t-rx"
+		;;
+	esac
 	extra_options="${extra_options} rx/elf.opt"
 	;;
 rx-*-linux*)

--- a/gcc/config/microblaze/microblaze.h
+++ b/gcc/config/microblaze/microblaze.h
@@ -115,7 +115,7 @@ extern enum pipeline_type microblaze_pipe;
   %{Zxl-mode-xmdstub:-defsym _TEXT_START_ADDR=0x800} \
   %{mxl-mode-xmdstub:-defsym _TEXT_START_ADDR=0x800} \
   %{mxl-gp-opt:%{G*}} %{!mxl-gp-opt: -G 0} \
-  %{!T*: %:if-exists-then-else(xilinx.ld%s -dT) %:if-exists(xilinx.ld%s)}"
+  %{!r:%{!T*: -dT xilinx.ld%s}}"
 
 /* Specs for the compiler proper  */
 

--- a/gcc/config/rx/rx.h
+++ b/gcc/config/rx/rx.h
@@ -115,7 +115,7 @@
 %{msim:-lsim}%{!msim:-lnosys}				\
 %{fprofile-arcs|fprofile-generate|coverage:-lgcov} 	\
 --end-group					   	\
-%{!T*: %{msim:%Trx-sim.ld}%{!msim:%Trx.ld}}		\
+%{!r:%{!T*: %{msim:%Trx-sim.ld}%{!msim:%Trx.ld}}}	\
 "
 
 #undef  LINK_SPEC

--- a/gcc/config/rx/rx.md
+++ b/gcc/config/rx/rx.md
@@ -2590,7 +2590,9 @@
    (clobber (reg:SI 3))
    (clobber (reg:CC CC_REG))]
   "rx_allow_string_insns"
-  "scmpu		; Perform the string comparison
+  "setpsw  z		; Set flags in case len is zero
+   setpsw  c
+   scmpu		; Perform the string comparison
    mov     #-1, %0      ; Set up -1 result (which cannot be created
                         ; by the SC insn)
    bnc	   ?+		; If Carry is not set skip over

--- a/gcc/config/rx/rx.md
+++ b/gcc/config/rx/rx.md
@@ -2541,10 +2541,20 @@
 	(unspec_volatile:SI [(match_operand:BLK 1 "memory_operand")     ;; String1
 			     (match_operand:BLK 2 "memory_operand")]    ;; String2
 			    UNSPEC_CMPSTRN))
-   (use (match_operand:SI                       3 "register_operand"))  ;; Max Length
+   (use (match_operand:SI                       3 "nonmemory_operand")) ;; Max Length
    (match_operand:SI                            4 "immediate_operand")] ;; Known Align
   "rx_allow_string_insns"
   {
+    bool const_len = CONST_INT_P(operands[3]);
+    if (const_len)
+    {
+      if (INTVAL(operands[3]) == 0)
+      {
+        emit_move_insn (operands[0], GEN_INT(0));
+        DONE;
+      }
+    }
+
     rtx str1 = gen_rtx_REG (SImode, 1);
     rtx str2 = gen_rtx_REG (SImode, 2);
     rtx len  = gen_rtx_REG (SImode, 3);
@@ -2553,6 +2563,11 @@
     emit_move_insn (str2, force_operand (XEXP (operands[2], 0), NULL_RTX));
     emit_move_insn (len, operands[3]);
 
+    /* Set flags in case len is zero */
+    if (!const_len) {
+      emit_insn (gen_setpsw (GEN_INT('C')));
+      emit_insn (gen_setpsw (GEN_INT('Z')));
+    }
     emit_insn (gen_rx_cmpstrn (operands[0], operands[1], operands[2]));
     DONE;
   }
@@ -2590,9 +2605,7 @@
    (clobber (reg:SI 3))
    (clobber (reg:CC CC_REG))]
   "rx_allow_string_insns"
-  "setpsw  z		; Set flags in case len is zero
-   setpsw  c
-   scmpu		; Perform the string comparison
+  "scmpu		; Perform the string comparison
    mov     #-1, %0      ; Set up -1 result (which cannot be created
                         ; by the SC insn)
    bnc	   ?+		; If Carry is not set skip over

--- a/gcc/config/rx/t-zephyr
+++ b/gcc/config/rx/t-zephyr
@@ -1,0 +1,37 @@
+# Makefile fragment for building GCC for the Renesas RX target.
+# Copyright (C) 2008-2022 Free Software Foundation, Inc.
+# Contributed by Red Hat.
+#
+# This file is part of GCC.
+#
+# GCC is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published
+# by the Free Software Foundation; either version 3, or (at your
+# option) any later version.
+#
+# GCC is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See
+# the GNU General Public License for more details.
+#
+# You should have received a copy of the  GNU General Public
+# License along with GCC; see the file COPYING3.  If not see
+# <http://www.gnu.org/licenses/>.
+
+# Enable multilibs:
+
+MULTILIB_OPTIONS    = m64bit-doubles  nofpu        mbig-endian-data  mpid
+MULTILIB_DIRNAMES   =  64-bit-double  no-fpu-libs   big-endian-data   pid
+
+# If necessary uncomment the next two lines to generate multilibs
+# using the old, broken, ABI.
+# MULTILIB_OPTIONS    += mgcc-abi
+# MULTILIB_DIRNAMES   +=  gcc-abi
+
+MULTILIB_OPTIONS   += mno-allow-string-insns
+MULTILIB_DIRNAMES  += no-strings
+
+MULTILIB_MATCHES    = nofpu=mnofpu  nofpu=mcpu?rx200  nofpu=mcpu?rx100
+
+MULTILIB_EXCEPTIONS =
+MULTILIB_EXTRA_OPTS =

--- a/libstdc++-v3/src/c++11/random.cc
+++ b/libstdc++-v3/src/c++11/random.cc
@@ -45,7 +45,7 @@
 #include <cstdio>
 #include <cctype> // For std::isdigit.
 
-#if defined _GLIBCXX_HAVE_UNISTD_H && defined _GLIBCXX_HAVE_FCNTL_H
+#if defined _GLIBCXX_HAVE_UNISTD_H && defined _GLIBCXX_HAVE_FCNTL_H && !defined _GLIBCXX_USE_STDIO_PURE
 # include <unistd.h>
 # include <fcntl.h>
 // Use POSIX open, close, read etc. instead of ISO fopen, fclose, fread


### PR DESCRIPTION
This removes a POSIX dependency from the library.

I'm not sure what branch to merge this into, but this patch targets gcc 12.2.0 for SDK 0.17.1