### PR TITLE
Move picolibc cpp additions to new LIBC_CPP_SPEC

### DIFF
--- a/gcc/config/picolibc-spec.h
+++ b/gcc/config/picolibc-spec.h
@@ -29,8 +29,8 @@
 #define OS_CC1_SPEC " %{!ftls-model=*:-ftls-model=local-exec}"
 
 /* Pass along preprocessor definitions when --printf or --scanf are specified */
-#undef CPP_SPEC
-#define CPP_SPEC				\
+#undef LIBC_CPP_SPEC
+#define LIBC_CPP_SPEC				\
   "%{-printf=*: -D_PICOLIBC_PRINTF='%*'}"	\
   " %{-scanf=*: -D_PICOLIBC_SCANF='%*'}"
 
@@ -39,8 +39,8 @@
  * Define vfprintf if --printf is set
  * Define vfscanf if --scanf is set
  */
-#undef LINK_LIBC_SPEC
-#define LINK_LIBC_SPEC							\
+#undef LIBC_LINK_SPEC
+#define LIBC_LINK_SPEC							\
   "%{!shared:%{!r:%{!T*: %:if-exists-then-else(%:find-file(" PICOLIBC_LD ") -T" PICOLIBC_LD ")}}}" \
   " %{-printf=*:--defsym=" USER_LABEL_PREFIX "vfprintf=" USER_LABEL_PREFIX "__%*_vfprintf}" \
   " %{-scanf=*:--defsym=" USER_LABEL_PREFIX "vfscanf=" USER_LABEL_PREFIX "__%*_vfscanf}"

--- a/gcc/gcc.cc
+++ b/gcc/gcc.cc
@@ -719,6 +719,13 @@ proper position among the other output files.  */
 #define CPP_SPEC ""
 #endif
 
+/* libc can define LIBC_CPP_SPEC to provide extra args to the C preprocessor
+   or extra switch-translations. */
+
+#ifndef LIBC_CPP_SPEC
+#define LIBC_CPP_SPEC ""
+#endif
+
 /* Operating systems can define OS_CC1_SPEC to provide extra args to cc1 and
    cc1plus or extra switch-translations.  The OS_CC1_SPEC is appended
    to CC1_SPEC in the initialization of cc1_spec.  */
@@ -742,6 +749,12 @@ proper position among the other output files.  */
    or extra switch-translations.  */
 #ifndef LINK_SPEC
 #define LINK_SPEC ""
+#endif
+
+/* libc can define LIBC_LINK_SPEC to provide extra args to the linker
+   or extra switch-translations.  */
+#ifndef LIBC_LINK_SPEC
+#define LIBC_LINK_SPEC ""
 #endif
 
 /* config.h can define LIB_SPEC to override the default libraries.  */
@@ -1197,14 +1210,14 @@ proper position among the other output files.  */
 
 static const char *asm_debug = ASM_DEBUG_SPEC;
 static const char *asm_debug_option = ASM_DEBUG_OPTION_SPEC;
-static const char *cpp_spec = CPP_SPEC;
+static const char *cpp_spec = CPP_SPEC LIBC_CPP_SPEC;
 static const char *cc1_spec = CC1_SPEC OS_CC1_SPEC;
 static const char *cc1plus_spec = CC1PLUS_SPEC;
 static const char *link_gcc_c_sequence_spec = LINK_GCC_C_SEQUENCE_SPEC;
 static const char *link_ssp_spec = LINK_SSP_SPEC;
 static const char *asm_spec = ASM_SPEC;
 static const char *asm_final_spec = ASM_FINAL_SPEC;
-static const char *link_spec = LINK_SPEC;
+static const char *link_spec = LINK_SPEC LIBC_LINK_SPEC;
 static const char *lib_spec = LIB_SPEC;
 static const char *link_gomp_spec = "";
 static const char *libgcc_spec = LIBGCC_SPEC;
@@ -1980,7 +1993,7 @@ init_spec (void)
 #endif
 
 #if defined LINK_EH_SPEC || defined LINK_BUILDID_SPEC || \
-    defined LINKER_HASH_STYLE || defined LINK_LIBC_SPEC
+    defined LINKER_HASH_STYLE
 # ifdef LINK_BUILDID_SPEC
   /* Prepend LINK_BUILDID_SPEC to whatever link_spec we had before.  */
   obstack_grow (&obstack, LINK_BUILDID_SPEC, sizeof (LINK_BUILDID_SPEC) - 1);
@@ -1998,10 +2011,6 @@ init_spec (void)
     obstack_grow (&obstack, LINKER_HASH_STYLE, sizeof (LINKER_HASH_STYLE) - 1);
     obstack_1grow (&obstack, ' ');
   }
-# endif
-# ifdef LINK_LIBC_SPEC
-  /* Prepend LINK_LIBC_SPEC to whatever link_spec we had before. */
-  obstack_grow (&obstack, LINK_LIBC_SPEC, sizeof (LINK_LIBC_SPEC) - 1);
 # endif
   obstack_grow0 (&obstack, link_spec, strlen (link_spec));
   link_spec = XOBFINISH (&obstack, const char *);


### PR DESCRIPTION
This avoids smashing target-specific CPP_SPEC values.