### PR TITLE
libstdc++-v3: Fix error in x86_64 zephyr support patch

### DIFF
--- a/libstdc++-v3/configure.host
+++ b/libstdc++-v3/configure.host
@@ -318,7 +318,6 @@ case "${host}" in
  loongarch*)
     tmake_file="cpu/loongarch/t-loongarch"
     ;;
- *-*-linux* | *-*-uclinux*)
  *-zephyr-elf*)
     case "${host_cpu}" in
       i[567]86)


### PR DESCRIPTION
Way back in 2019, b1bdbab498781fca65b64dfb7f36e3ba4c24a31a added x86_64 zephyr support. That included a duplicate line which causes a syntax error in this file.
