### PR TITLE
When using multilib-space, disable C++ exceptions in -Os versions

### DIFF
--- a/config-ml.in
+++ b/config-ml.in
@@ -514,6 +514,8 @@ multi-do:
 	    else \
 	      if [ -d ../$${dir}/$${lib} ]; then \
 		flags=`echo $$i | sed -e 's/^[^;]*;//' -e 's/@/ -/g'`; \
+		cxxflags='$${flags}'; \
+		case "$$i" in *@Os*) cxxflags="$${flags} -fno-exceptions -fno-asynchronous-unwind-tables"; ;; esac ; \
 		if (cd ../$${dir}/$${lib}; $(MAKE) $(FLAGS_TO_PASS) \
 				CFLAGS="$(CFLAGS) $${flags}" \
 				CCASFLAGS="$(CCASFLAGS) $${flags}" \
@@ -524,9 +526,9 @@ multi-do:
 				exec_prefix="$(exec_prefix)" \
 				GOCFLAGS="$(GOCFLAGS) $${flags}" \
 				GDCFLAGS="$(GDCFLAGS) $${flags}" \
-				CXXFLAGS="$(CXXFLAGS) $${flags}" \
+				CXXFLAGS="$(CXXFLAGS) $${cxxflags}" \
 				LIBCFLAGS="$(LIBCFLAGS) $${flags}" \
-				LIBCXXFLAGS="$(LIBCXXFLAGS) $${flags}" \
+				LIBCXXFLAGS="$(LIBCXXFLAGS) $${cxxflags}" \
 				LDFLAGS="$(LDFLAGS) $${flags}" \
 				MULTIFLAGS="$${flags}" \
 				DESTDIR="$(DESTDIR)" \


### PR DESCRIPTION
Let's provide a version of libstdc++ without exception support. As that is a space saving choice, we'll tie it to the -Os multilib variants.
