### PR TITLE
RISC-V: Add RV32E Zcb multi-libs

### DIFF
--- a/gcc/config/riscv/t-zephyr
+++ b/gcc/config/riscv/t-zephyr
@@ -26,6 +26,8 @@ MULTILIB_SRC_ARCH += rv32emc_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv32emc_zicsr_zifencei_zba_zbb_zbc_zbs
 MULTILIB_SRC_ARCH += rv32emc_zicsr
 MULTILIB_SRC_ARCH += rv32emc_zicsr_zba_zbb_zbc_zbs
+MULTILIB_SRC_ARCH += rv32emc_zicsr_zcb_zba_zbb_zbc_zbs
+MULTILIB_SRC_ARCH += rv32emc_zicntr_zicsr_zcb_zba_zbb_zbc_zbs
 MULTILIB_SRC_ARCH += rv32emac_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv32emac_zicsr_zifencei_zba_zbb_zbc_zbs
 MULTILIB_SRC_ARCH += rv32ea_zicsr_zifencei
@@ -76,6 +78,7 @@ march=rv32emc_zicsr_zifencei/mabi=ilp32e \
 march=rv32emc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi=ilp32e \
 march=rv32emc_zicsr/mabi=ilp32e \
 march=rv32emc_zicsr_zba_zbb_zbc_zbs/mabi=ilp32e \
+march=rv32emc_zicsr_zcb_zba_zbb_zbc_zbs/mabi=ilp32e \
 march=rv64i_zicsr_zifencei/mabi=lp64/mcmodel=medany \
 march=rv64im_zicsr_zifencei/mabi=lp64/mcmodel=medany \
 march=rv64im_zicsr_zifencei_zba_zbb_zbc_zbs/mabi=lp64/mcmodel=medany \
@@ -107,6 +110,7 @@ march.rv32e_zicsr_zifencei/mabi.ilp32e=march.rv32ec_zicsr_zifencei/mabi.ilp32e \
 march.rv32em_zicsr_zifencei/mabi.ilp32e=march.rv32ema_zicsr_zifencei/mabi.ilp32e \
 march.rv32emc_zicsr_zifencei/mabi.ilp32e=march.rv32emac_zicsr_zifencei/mabi.ilp32e \
 march.rv32emc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.ilp32e=march.rv32emac_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.ilp32e \
+march.rv32emc_zicsr_zcb_zba_zbb_zbc_zbs/mabi.ilp32e=march.rv32emc_zicntr_zicsr_zcb_zba_zbb_zbc_zbs/mabi.ilp32e \
 march.rv64i_zicsr_zifencei/mabi.lp64/mcmodel.medany=march.rv64i_zicsr_zifencei/mabi.lp64 \
 march.rv64im_zicsr_zifencei/mabi.lp64/mcmodel.medany=march.rv64im_zicsr_zifencei/mabi.lp64 \
 march.rv64im_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64/mcmodel.medany=march.rv64im_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64 \


### PR DESCRIPTION
This commit introduces a new multi-lib build for RV32E with Zcb
extension enabled: rv32emc_zicsr_zcb_zba_zbb_zbc_zbs.

The Zcb extension is a set of compressed instructions designed to reduce
code size for small microcontrollers and is an ideal combination for the
RV32E ISA.

rv32emc_zicsr_zcb_zba_zbb_zbc_zbs multi-lib build is also mapped to
rv32emc_zicntr_zicsr_zcb_zba_zbb_zbc_zbs.