### PR TITLE
RISC-V: Add RV64GC Bitmanip multi-lib

### DIFF
--- a/gcc/config/riscv/t-zephyr
+++ b/gcc/config/riscv/t-zephyr
@@ -119,6 +119,7 @@ march.rv64imafdc_zicsr_zifencei/mabi.lp64d/mcmodel.medany=march.rv64imafdc_zicsr
 march.rv64imafdc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64d/mcmodel.medany=march.rv64imafdc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64d \
 march.rv64imafd_zicsr_zifencei/mabi.lp64d/mcmodel.medany=march.rv64imafd_zicsr_zifencei/mabi.lp64d \
 march.rv64imfc_zicsr_zifencei/mabi.lp64f/mcmodel.medany=march.rv64imfc_zicsr_zifencei/mabi.lp64f \
+march.rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64f/mcmodel.medany=march.rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64f \
 march.rv64i_zicsr_zifencei/mabi.lp64/mcmodel.medany=march.rv64ia_zicsr_zifencei/mabi.lp64/mcmodel.medany \
 march.rv64i_zicsr_zifencei/mabi.lp64/mcmodel.medany=march.rv64ia_zicsr_zifencei/mabi.lp64 \
 march.rv64i_zicsr_zifencei/mabi.lp64/mcmodel.medany=march.rv64iac_zicsr_zifencei/mabi.lp64/mcmodel.medany \

--- a/gcc/config/riscv/t-zephyr
+++ b/gcc/config/riscv/t-zephyr
@@ -40,6 +40,7 @@ MULTILIB_SRC_ARCH += rv64imac_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv64imac_zicsr_zifencei_zba_zbb_zbc_zbs
 MULTILIB_SRC_ARCH += rv64imafd_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv64imafdc_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv64imafdc_zicsr_zifencei_zba_zbb_zbc_zbs
 MULTILIB_SRC_ARCH += rv64imc_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv64imc_zicsr_zifencei_zba_zbb_zbc_zbs
 MULTILIB_SRC_ARCH += rv64imfc_zicsr_zifencei
@@ -49,6 +50,7 @@ MULTILIB_SRC_ARCH += rv64iac_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv64ic_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv64g
 MULTILIB_SRC_ARCH += rv64gc
+MULTILIB_SRC_ARCH += rv64gc_zba_zbb_zbc_zbs
 
 MULTILIB_SRC_ABI  = ilp32
 MULTILIB_SRC_ABI += ilp32f
@@ -82,6 +84,7 @@ march=rv64im_zicsr_zifencei_zba_zbb_zbc_zbs/mabi=lp64/mcmodel=medany \
 march=rv64imac_zicsr_zifencei/mabi=lp64/mcmodel=medany \
 march=rv64imac_zicsr_zifencei_zba_zbb_zbc_zbs/mabi=lp64/mcmodel=medany \
 march=rv64imafdc_zicsr_zifencei/mabi=lp64d/mcmodel=medany \
+march=rv64imafdc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi=lp64d/mcmodel=medany \
 march=rv64imafd_zicsr_zifencei/mabi=lp64d/mcmodel=medany \
 march=rv64imfc_zicsr_zifencei/mabi=lp64f/mcmodel=medany \
 march=rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi=lp64f/mcmodel=medany
@@ -113,6 +116,7 @@ march.rv64im_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64/mcmodel.medany=march.rv64i
 march.rv64imac_zicsr_zifencei/mabi.lp64/mcmodel.medany=march.rv64imac_zicsr_zifencei/mabi.lp64 \
 march.rv64imac_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64/mcmodel.medany=march.rv64imac_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64 \
 march.rv64imafdc_zicsr_zifencei/mabi.lp64d/mcmodel.medany=march.rv64imafdc_zicsr_zifencei/mabi.lp64d \
+march.rv64imafdc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64d/mcmodel.medany=march.rv64imafdc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64d \
 march.rv64imafd_zicsr_zifencei/mabi.lp64d/mcmodel.medany=march.rv64imafd_zicsr_zifencei/mabi.lp64d \
 march.rv64imfc_zicsr_zifencei/mabi.lp64f/mcmodel.medany=march.rv64imfc_zicsr_zifencei/mabi.lp64f \
 march.rv64i_zicsr_zifencei/mabi.lp64/mcmodel.medany=march.rv64ia_zicsr_zifencei/mabi.lp64/mcmodel.medany \
@@ -131,6 +135,8 @@ march.rv64im_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64/mcmodel.medany=march.rv64i
 march.rv64im_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64/mcmodel.medany=march.rv64imc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64 \
 march.rv64imafdc_zicsr_zifencei/mabi.lp64d/mcmodel.medany=march.rv64gc/mabi.lp64d/mcmodel.medany \
 march.rv64imafdc_zicsr_zifencei/mabi.lp64d/mcmodel.medany=march.rv64gc/mabi.lp64d \
+march.rv64imafdc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64d/mcmodel.medany=march.rv64gc_zba_zbb_zbc_zbs/mabi.lp64d/mcmodel.medany \
+march.rv64imafdc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64d/mcmodel.medany=march.rv64gc_zba_zbb_zbc_zbs/mabi.lp64d \
 march.rv64imafd_zicsr_zifencei/mabi.lp64d/mcmodel.medany=march.rv64g/mabi.lp64d/mcmodel.medany \
 march.rv64imafd_zicsr_zifencei/mabi.lp64d/mcmodel.medany=march.rv64g/mabi.lp64d
 


### PR DESCRIPTION
This commit introduces a new multi-lib build for RV64GC with Bitmanip extensions enabled: rv64imafdc_zicsr_zifencei_zba_zbb_zbc_zbs -- note that `rv64g` is an alias for `rv64imafd`.

This allows the usage of the bit manipulation extension instructions with the widely used "G" (general purpose computing) ISA.
