### PR TITLE
RISC-V: Add RV64GC large code model multi-lib

### DIFF
--- a/gcc/config/riscv/t-zephyr
+++ b/gcc/config/riscv/t-zephyr
@@ -63,6 +63,7 @@ MULTILIB_SRC_ABI += lp64f
 MULTILIB_SRC_ABI += lp64d
 
 MULTILIB_SRC_MCMODEL  = medany
+MULTILIB_SRC_MCMODEL += large
 
 # Multilib build configurations
 MULTILIB_REQUIRED = \
@@ -87,6 +88,7 @@ march=rv64im_zicsr_zifencei_zba_zbb_zbc_zbs/mabi=lp64/mcmodel=medany \
 march=rv64imac_zicsr_zifencei/mabi=lp64/mcmodel=medany \
 march=rv64imac_zicsr_zifencei_zba_zbb_zbc_zbs/mabi=lp64/mcmodel=medany \
 march=rv64imafdc_zicsr_zifencei/mabi=lp64d/mcmodel=medany \
+march=rv64imafdc_zicsr_zifencei/mabi=lp64d/mcmodel=large \
 march=rv64imafdc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi=lp64d/mcmodel=medany \
 march=rv64imafd_zicsr_zifencei/mabi=lp64d/mcmodel=medany \
 march=rv64imfc_zicsr_zifencei/mabi=lp64f/mcmodel=medany \
@@ -140,6 +142,7 @@ march.rv64im_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64/mcmodel.medany=march.rv64i
 march.rv64im_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64/mcmodel.medany=march.rv64imc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64 \
 march.rv64imafdc_zicsr_zifencei/mabi.lp64d/mcmodel.medany=march.rv64gc/mabi.lp64d/mcmodel.medany \
 march.rv64imafdc_zicsr_zifencei/mabi.lp64d/mcmodel.medany=march.rv64gc/mabi.lp64d \
+march.rv64imafdc_zicsr_zifencei/mabi.lp64d/mcmodel.large=march.rv64gc/mabi.lp64d/mcmodel.large \
 march.rv64imafdc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64d/mcmodel.medany=march.rv64gc_zba_zbb_zbc_zbs/mabi.lp64d/mcmodel.medany \
 march.rv64imafdc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64d/mcmodel.medany=march.rv64gc_zba_zbb_zbc_zbs/mabi.lp64d \
 march.rv64imafd_zicsr_zifencei/mabi.lp64d/mcmodel.medany=march.rv64g/mabi.lp64d/mcmodel.medany \


### PR DESCRIPTION
This commit adds a new multi-lib build for rv64gc (aka. rv64imafdc) with
large code model (`-mcmodel=large`).

The large code model is required to handle offsets larger than 2GiB.

---

Includes the commits from https://github.com/zephyrproject-rtos/gcc/pull/51