### PR TITLE
Enable long path support on Windows host

### DIFF
--- a/gcc/config/i386/winnt-utf8.manifest
+++ b/gcc/config/i386/winnt-utf8.manifest
@@ -3,6 +3,7 @@
   <application>
     <windowsSettings>
       <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </windowsSettings>
   </application>
 </assembly>


### PR DESCRIPTION
Declare `longPathAware` in the GCC executable manifest to allow GCC executables to address paths longer than `MAX_PATH`, which is 260 characters, on Windows hosts.

Note that this alone is not sufficient to enable long path support on Windows; the corresponding registry key must also be enabled. For more details, refer to the Microsoft documentation [1].

[1] https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation