### PR TITLE
config/microblaze: fix whitespace in LINK_SPEC is breaking linking

### DIFF
--- a/gcc/config/microblaze/microblaze.h
+++ b/gcc/config/microblaze/microblaze.h
@@ -115,7 +115,7 @@ extern enum pipeline_type microblaze_pipe;
   %{Zxl-mode-xmdstub:-defsym _TEXT_START_ADDR=0x800} \
   %{mxl-mode-xmdstub:-defsym _TEXT_START_ADDR=0x800} \
   %{mxl-gp-opt:%{G*}} %{!mxl-gp-opt: -G 0} \
-  %{!r:%{!T*: %:if-exists-then-else(%:find-file(xilinx.ld) -dT xilinx.ld%s)}}"
+  %{!r:%{!T*: %:if-exists-then-else(%:find-file(xilinx.ld) -dTxilinx.ld%s)}}"
 
 /* Specs for the compiler proper  */
 


### PR DESCRIPTION
whitespace is causing the intended output of `-dT xilinx.ld%s` to be split and takeninto if-exists-then-else as 2nd and 3rd arguments so LINK_SPEC emits `-dT` when xilinx.ld is found, and emits xilinx.ld when not found.

**Testing:**
I've sneakily pushed this patch into #58 to get a toolchain out and tested it with picolibc.