### PR TITLE
arm_mve: Use inline asm for lsll and asrl MVE primitives

### DIFF
--- a/gcc/config/arm/arm_mve.h
+++ b/gcc/config/arm/arm_mve.h
@@ -3580,14 +3580,16 @@ __extension__ extern __inline  uint64_t
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 __arm_lsll (uint64_t value, int32_t shift)
 {
-  return (value << shift);
+  __asm__("lsll %Q0, %R0, %1" : "+r" (value) : "rPg" (shift));
+  return value;
 }
 
 __extension__ extern __inline int64_t
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 __arm_asrl (int64_t value, int32_t shift)
 {
-  return (value >> shift);
+  __asm__("asrl %Q0, %R0, %1" : "+r" (value) : "rPg" (shift));
+  return value;
 }
 
 __extension__ extern __inline uint64_t


### PR DESCRIPTION
The C shift operators do not precisely match the associated ARM instructions: shifts of negative values or by negative amounts are undefined behavior in C, and GCC may substitute alternate instruction sequences when it can determine that the application is using UB.

Replace C shift operators with inline asm to ensure the lsll and asrl primitives always emit the indicated instruction.

This issue caused mis-compilation of the ARM cmsis-dsp code for arm_biquad_cascade_df1_32x64_q31:

	https://github.com/ARM-software/CMSIS-DSP/pull/265

This has been submitted upstream to GCC:

	https://gcc.gnu.org/pipermail/gcc-patches/2025-August/692431.html
