### PR TITLE
rx: Reduce RX toolchain multilib variants for Zephyr

### DIFF
--- a/gcc/config/rx/t-zephyr
+++ b/gcc/config/rx/t-zephyr
@@ -23,126 +23,44 @@ rx-pragma.o: $(srcdir)/config/rx/rx-pragma.c $(RTL_H) $(TREE_H) $(CONFIG_H) $(TM
 
 # Enable multilibs:
 
-MULTILIB_OPTIONS    = m64bit-doubles  nofpu        mbig-endian-data  mjsr mdfpu
-MULTILIB_DIRNAMES   =  64-bit-double  no-fpu-libs   big-endian-data  jsr dfpu
+MULTILIB_OPTIONS    = m64bit-doubles nofpu mjsr mcpu=rx64m misa=v3 mdfpu
+MULTILIB_DIRNAMES   = 64-bit-double no-fpu-libs jsr rxv2 rxv3 dfpu
 
-# If necessary uncomment the next two lines to generate multilibs
-# using the old, broken, ABI.
-# MULTILIB_OPTIONS    += mgcc-abi
-# MULTILIB_DIRNAMES   +=  gcc-abi
-
-
-MULTILIB_OPTIONS   += mno-allow-string-insns
-MULTILIB_DIRNAMES  += no-strings
-
-
-MULTILIB_OPTIONS   += mcpu=rx64m
-MULTILIB_DIRNAMES  += rxv2
-
-MULTILIB_MATCHES    = nofpu=mnofpu  nofpu=mcpu?rx200  nofpu=mcpu?rx100
+MULTILIB_MATCHES    = nofpu=mnofpu nofpu=mcpu?rx200 nofpu=mcpu?rx100
 
 MULTILIB_EXCEPTIONS =
-MULTILIB_EXTRA_OPTS =
-
-MULTILIB_OPTIONS   += misa=v3
-MULTILIB_DIRNAMES  += rxv3
-MULTILIB_EXCEPTIONS  += *mcpu=*/*misa=v3*
+MULTILIB_EXCEPTIONS += *mcpu=rx64m*/*mdfpu*
+MULTILIB_EXCEPTIONS += *mcpu=*/*misa=v3*
 
 MULTILIB_REQUIRED =
 MULTILIB_REQUIRED += m64bit-doubles
-MULTILIB_REQUIRED += nofpu
-MULTILIB_REQUIRED += mbig-endian-data
-MULTILIB_REQUIRED += mjsr
-MULTILIB_REQUIRED += mno-allow-string-insns
 MULTILIB_REQUIRED += mcpu=rx64m
 MULTILIB_REQUIRED += misa=v3
-MULTILIB_REQUIRED += mno-allow-string-insns/mcpu=rx64m
-MULTILIB_REQUIRED += mno-allow-string-insns/misa=v3
-MULTILIB_REQUIRED += mjsr/mno-allow-string-insns
-MULTILIB_REQUIRED += mjsr/mcpu=rx64m
-MULTILIB_REQUIRED += mjsr/misa=v3
-MULTILIB_REQUIRED += mjsr/mno-allow-string-insns/mcpu=rx64m
-MULTILIB_REQUIRED += mjsr/mno-allow-string-insns/misa=v3
-MULTILIB_REQUIRED += mbig-endian-data/mjsr
-MULTILIB_REQUIRED += mbig-endian-data/mno-allow-string-insns
-MULTILIB_REQUIRED += mbig-endian-data/mcpu=rx64m
-MULTILIB_REQUIRED += mbig-endian-data/misa=v3
-MULTILIB_REQUIRED += mbig-endian-data/mno-allow-string-insns/mcpu=rx64m
-MULTILIB_REQUIRED += mbig-endian-data/mno-allow-string-insns/misa=v3
-MULTILIB_REQUIRED += mbig-endian-data/mjsr/mno-allow-string-insns
-MULTILIB_REQUIRED += mbig-endian-data/mjsr/mcpu=rx64m
-MULTILIB_REQUIRED += mbig-endian-data/mjsr/misa=v3
-MULTILIB_REQUIRED += mbig-endian-data/mjsr/mno-allow-string-insns/mcpu=rx64m
-MULTILIB_REQUIRED += mbig-endian-data/mjsr/mno-allow-string-insns/misa=v3
-MULTILIB_REQUIRED += nofpu/mbig-endian-data
-MULTILIB_REQUIRED += nofpu/mjsr
-MULTILIB_REQUIRED += nofpu/mno-allow-string-insns
-MULTILIB_REQUIRED += nofpu/mcpu=rx64m
-MULTILIB_REQUIRED += nofpu/misa=v3
-MULTILIB_REQUIRED += nofpu/mno-allow-string-insns/mcpu=rx64m
-MULTILIB_REQUIRED += nofpu/mno-allow-string-insns/misa=v3
-MULTILIB_REQUIRED += nofpu/mjsr/mno-allow-string-insns
-MULTILIB_REQUIRED += nofpu/mjsr/mcpu=rx64m
-MULTILIB_REQUIRED += nofpu/mjsr/misa=v3
-MULTILIB_REQUIRED += nofpu/mjsr/mno-allow-string-insns/mcpu=rx64m
-MULTILIB_REQUIRED += nofpu/mjsr/mno-allow-string-insns/misa=v3
-MULTILIB_REQUIRED += nofpu/mbig-endian-data/mjsr
-MULTILIB_REQUIRED += nofpu/mbig-endian-data/mno-allow-string-insns
-MULTILIB_REQUIRED += nofpu/mbig-endian-data/mcpu=rx64m
-MULTILIB_REQUIRED += nofpu/mbig-endian-data/misa=v3
-MULTILIB_REQUIRED += nofpu/mbig-endian-data/mno-allow-string-insns/mcpu=rx64m
-MULTILIB_REQUIRED += nofpu/mbig-endian-data/mno-allow-string-insns/misa=v3
-MULTILIB_REQUIRED += nofpu/mbig-endian-data/mjsr/mno-allow-string-insns
-MULTILIB_REQUIRED += nofpu/mbig-endian-data/mjsr/mcpu=rx64m
-MULTILIB_REQUIRED += nofpu/mbig-endian-data/mjsr/misa=v3
-MULTILIB_REQUIRED += nofpu/mbig-endian-data/mjsr/mno-allow-string-insns/mcpu=rx64m
-MULTILIB_REQUIRED += nofpu/mbig-endian-data/mjsr/mno-allow-string-insns/misa=v3
-MULTILIB_REQUIRED += m64bit-doubles/nofpu
-MULTILIB_REQUIRED += m64bit-doubles/mbig-endian-data
-MULTILIB_REQUIRED += m64bit-doubles/mjsr
-MULTILIB_REQUIRED += m64bit-doubles/mno-allow-string-insns
-MULTILIB_REQUIRED += m64bit-doubles/mcpu=rx64m
-MULTILIB_REQUIRED += m64bit-doubles/misa=v3
-MULTILIB_REQUIRED += m64bit-doubles/mno-allow-string-insns/mcpu=rx64m
-MULTILIB_REQUIRED += m64bit-doubles/mno-allow-string-insns/misa=v3
-MULTILIB_REQUIRED += m64bit-doubles/mjsr/mno-allow-string-insns
-MULTILIB_REQUIRED += m64bit-doubles/mjsr/mcpu=rx64m
-MULTILIB_REQUIRED += m64bit-doubles/mjsr/misa=v3
-MULTILIB_REQUIRED += m64bit-doubles/mjsr/mno-allow-string-insns/mcpu=rx64m
-MULTILIB_REQUIRED += m64bit-doubles/mjsr/mno-allow-string-insns/misa=v3
-MULTILIB_REQUIRED += m64bit-doubles/mbig-endian-data/mjsr
-MULTILIB_REQUIRED += m64bit-doubles/mbig-endian-data/mno-allow-string-insns
-MULTILIB_REQUIRED += m64bit-doubles/mbig-endian-data/mcpu=rx64m
-MULTILIB_REQUIRED += m64bit-doubles/mbig-endian-data/misa=v3
-MULTILIB_REQUIRED += m64bit-doubles/mbig-endian-data/mno-allow-string-insns/mcpu=rx64m
-MULTILIB_REQUIRED += m64bit-doubles/mbig-endian-data/mno-allow-string-insns/misa=v3
-MULTILIB_REQUIRED += m64bit-doubles/mbig-endian-data/mjsr/mno-allow-string-insns
-MULTILIB_REQUIRED += m64bit-doubles/mbig-endian-data/mjsr/mcpu=rx64m
-MULTILIB_REQUIRED += m64bit-doubles/mbig-endian-data/mjsr/misa=v3
-MULTILIB_REQUIRED += m64bit-doubles/mbig-endian-data/mjsr/mno-allow-string-insns/mcpu=rx64m
-MULTILIB_REQUIRED += m64bit-doubles/mbig-endian-data/mjsr/mno-allow-string-insns/misa=v3
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mbig-endian-data
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mjsr
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mno-allow-string-insns
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mcpu=rx64m
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/misa=v3
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mno-allow-string-insns/mcpu=rx64m
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mno-allow-string-insns/misa=v3
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mjsr/mno-allow-string-insns
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mjsr/mcpu=rx64m
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mjsr/misa=v3
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mjsr/mno-allow-string-insns/mcpu=rx64m
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mjsr/mno-allow-string-insns/misa=v3
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mbig-endian-data/mjsr
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mbig-endian-data/mno-allow-string-insns
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mbig-endian-data/mcpu=rx64m
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mbig-endian-data/misa=v3
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mbig-endian-data/mno-allow-string-insns/mcpu=rx64m
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mbig-endian-data/mno-allow-string-insns/misa=v3
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mbig-endian-data/mjsr/mno-allow-string-insns
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mbig-endian-data/mjsr/mcpu=rx64m
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mbig-endian-data/mjsr/misa=v3
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mbig-endian-data/mjsr/mno-allow-string-insns/mcpu=rx64m
-MULTILIB_REQUIRED += m64bit-doubles/nofpu/mbig-endian-data/mjsr/mno-allow-string-insns/misa=v3
+MULTILIB_REQUIRED += nofpu
+MULTILIB_REQUIRED += mjsr
 
-MULTILIB_REQUIRED += m64bit-doubles/mdfpu/misa=v3
+MULTILIB_REQUIRED += m64bit-doubles/nofpu
+MULTILIB_REQUIRED += m64bit-doubles/mjsr
+MULTILIB_REQUIRED += m64bit-doubles/nofpu/mjsr
+
+MULTILIB_REQUIRED += mcpu=rx64m/nofpu
+MULTILIB_REQUIRED += mcpu=rx64m/mjsr
+MULTILIB_REQUIRED += mcpu=rx64m/nofpu/mjsr
+MULTILIB_REQUIRED += m64bit-doubles/mcpu=rx64m
+MULTILIB_REQUIRED += m64bit-doubles/mcpu=rx64m/nofpu
+MULTILIB_REQUIRED += m64bit-doubles/mcpu=rx64m/mjsr
+MULTILIB_REQUIRED += m64bit-doubles/mcpu=rx64m/nofpu/mjsr
+
+MULTILIB_REQUIRED += misa=v3/mjsr
+MULTILIB_REQUIRED += misa=v3/nofpu
+MULTILIB_REQUIRED += misa=v3/nofpu/mjsr
+MULTILIB_REQUIRED += misa=v3/mdfpu
+MULTILIB_REQUIRED += misa=v3/mdfpu/mjsr
+MULTILIB_REQUIRED += m64bit-doubles/misa=v3
+MULTILIB_REQUIRED += m64bit-doubles/misa=v3/mjsr
+MULTILIB_REQUIRED += m64bit-doubles/misa=v3/nofpu
+MULTILIB_REQUIRED += m64bit-doubles/misa=v3/nofpu/mjsr
+MULTILIB_REQUIRED += m64bit-doubles/misa=v3/mdfpu
+MULTILIB_REQUIRED += m64bit-doubles/misa=v3/mdfpu/mjsr
+
+MULTILIB_REQUIRED += nofpu/mjsr


### PR DESCRIPTION
This change reduces the multilib configuration to only the variants actually required by Zephyr:
- RXv2 (misa=v2) and RXv3 (misa=v3) architectures
- FPU variants: default FPU, nofpu, and mdfpu (RXv3 only)
- JSR calling convention support
- 64-bit double precision support