### PR TITLE
Adapt picolibc support from upstream gcc

### DIFF
--- a/gcc/c-family/cppspec.cc
+++ b/gcc/c-family/cppspec.cc
@@ -198,3 +198,6 @@ int lang_specific_pre_link (void)
 
 /* Number of extra output files that lang_specific_pre_link may generate.  */
 int lang_specific_extra_outfiles = 0;  /* Not used for cpp.  */
+
+/* Language target for this driver */
+const char *lang_specific_language = NULL;

--- a/gcc/c/gccspec.cc
+++ b/gcc/c/gccspec.cc
@@ -105,3 +105,6 @@ lang_specific_pre_link (void)
 
 /* Number of extra output files that lang_specific_pre_link may generate.  */
 int lang_specific_extra_outfiles = 0;  /* Not used for C.  */
+
+/* Language target for this driver */
+const char *lang_specific_language = "c";

--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -693,9 +693,7 @@ case ${target} in
 esac
 
 # Common C libraries.
-tm_defines="$tm_defines LIBC_GLIBC=1 LIBC_UCLIBC=2 LIBC_BIONIC=3 LIBC_MUSL=4 LIBC_PICOLIBC=5"
-
-default_libc=""
+tm_defines="$tm_defines LIBC_GLIBC=1 LIBC_UCLIBC=2 LIBC_BIONIC=3 LIBC_MUSL=4"
 
 # 32-bit x86 processors supported by --with-arch=.  Each processor
 # MUST be separated by exactly one space.
@@ -913,16 +911,16 @@ case ${target} in
   esac
   case $target in
     *-*-*android*)
-      default_libc=LIBC_BIONIC
+      tm_defines="$tm_defines DEFAULT_LIBC=LIBC_BIONIC"
       ;;
     *-*-*uclibc* | *-*-uclinuxfdpiceabi)
-      default_libc=LIBC_UCLIBC
+      tm_defines="$tm_defines DEFAULT_LIBC=LIBC_UCLIBC"
       ;;
     *-*-*musl*)
-      default_libc=LIBC_MUSL
+      tm_defines="$tm_defines DEFAULT_LIBC=LIBC_MUSL"
       ;;
     *)
-      default_libc=LIBC_GLIBC
+      tm_defines="$tm_defines DEFAULT_LIBC=LIBC_GLIBC"
       ;;
   esac
   # Assume that glibc or uClibc or Bionic are being used and so __cxa_atexit
@@ -1037,8 +1035,7 @@ case ${target} in
   case ${enable_threads} in
     "" | yes | posix) thread_file='posix' ;;
   esac
-  tm_defines="$tm_defines SINGLE_LIBC"
-  default_libc=LIBC_UCLIBC
+  tm_defines="$tm_defines DEFAULT_LIBC=LIBC_UCLIBC SINGLE_LIBC"
   ;;
 *-*-rdos*)
   use_gcc_stdint=wrap
@@ -1168,10 +1165,6 @@ case ${target} in
       ;;
   esac
   ;;
-*-picolibc-*)
-  default_libc=LIBC_PICOLIBC
-  ;;
-
 *-*-elf|arc*-*-elf*)
   # Assume that newlib is being used and so __cxa_atexit is provided.
   default_use_cxa_atexit=yes
@@ -1728,13 +1721,13 @@ csky-*-*)
 
 		case ${target} in
 		    csky-*-linux-gnu*)
-			default_libc=LIBC_GLIBC
+			tm_defines="$tm_defines DEFAULT_LIBC=LIBC_GLIBC"
 			# Force .init_array support.  The configure script cannot always
 			# automatically detect that GAS supports it, yet we require it.
 			gcc_cv_initfini_array=yes
 			;;
 		    csky-*-linux-uclibc*)
-			default_libc=LIBC_UCLIBC
+			tm_defines="$tm_defines DEFAULT_LIBC=LIBC_UCLIBC"
 			default_use_cxa_atexit=no
 			;;
 		    *)
@@ -3144,7 +3137,7 @@ powerpc*-wrs-vxworks7r*)
 	tmake_file="${tmake_file} t-linux rs6000/t-linux64 rs6000/t-fprules rs6000/t-ppccomm"
 	tmake_file="${tmake_file} rs6000/t-vxworks"
 
-	default_libc=LIBC_GLIBC
+	tm_defines="$tm_defines DEFAULT_LIBC=LIBC_GLIBC"
 	extra_objs="$extra_objs linux.o rs6000-linux.o"
 	;;
 powerpc-wrs-vxworks*)
@@ -3674,6 +3667,24 @@ case ${target} in
 	;;
 *-linux-uclibc*)
 	tmake_file="${tmake_file} t-uclibc"
+	;;
+esac
+
+# picolibc systems
+case "${target}_${with_picolibc}" in
+*-picolibc-*|*_yes)
+	default_use_cxa_atexit=yes
+	use_gcc_stdint=none
+	# add newlib-stdint.h if not already present
+	case "${tm_file}" in
+	*newlib-stdint.h*)
+		;;
+	*)
+		tm_file="${tm_file} newlib-stdint.h"
+		;;
+	esac
+	tm_file="${tm_file} picolibc-spec.h"
+	extra_options="${extra_options} picolibc.opt"
 	;;
 esac
 
@@ -6111,53 +6122,3 @@ i[34567]86-*-* | x86_64-*-*)
 	;;
 esac
 
-case "${with_default_libc}" in
-glibc)
-    default_libc=LIBC_GLIBC
-    ;;
-uclibc)
-    default_libc=LIBC_UCLIBC
-    ;;
-bionic)
-    default_libc=LIBC_BIONIC
-    ;;
-musl)
-    default_libc=LIBC_MUSL
-    ;;
-newlib)
-    # Newlib configurations don't set the DEFAULT_LIBC variable, so
-    # avoid changing those by allowing --with-default-libc=newlib but
-    # not actually setting the DEFAULT_LIBC variable.
-    default_libc=
-    ;;
-picolibc)
-    default_libc=LIBC_PICOLIBC
-    ;;
-"")
-    ;;
-*)
-    echo "Unknown libc in --with-default-libc=$with_default_libc" 1>&2
-    exit 1
-    ;;
-esac
-
-case "$default_libc" in
-"")
-    ;;
-*)
-    tm_defines="$tm_defines DEFAULT_LIBC=$default_libc"
-    ;;
-esac
-
-# Targets for picolibc should include picolibc-spec.h to allow
-# use of picolibc-specific compiler flags
-case "$default_libc" in
-LIBC_PICOLIBC)
-    # __cxa_atexit is provided.
-    default_use_cxa_atexit=yes
-    # picolibc provides stdint.h
-    use_gcc_stdint=none
-    tm_file="${tm_file} picolibc-spec.h"
-    extra_options="${extra_options} picolibc.opt"
-    ;;
-esac

--- a/gcc/config/arc/arc.cc
+++ b/gcc/config/arc/arc.cc
@@ -4580,6 +4580,8 @@ arc_split_ashr (rtx *operands)
       else if (n == 30)
 	{
 	  rtx tmp = gen_reg_rtx (SImode);
+	  emit_insn(gen_rtx_CLOBBER(VOIDmode, gen_rtx_REG(SImode, LP_COUNT)));
+	  emit_insn(gen_rtx_CLOBBER(VOIDmode, gen_rtx_REG(CCmode, CC_REG)));
 	  emit_insn (gen_add_f (tmp, operands[1], operands[1]));
 	  emit_insn (gen_sbc (operands[0], operands[0], operands[0]));
 	  emit_insn (gen_addsi_compare_2 (tmp, tmp));
@@ -4588,6 +4590,8 @@ arc_split_ashr (rtx *operands)
 	}
       else if (n == 31)
 	{
+	  emit_insn(gen_rtx_CLOBBER(VOIDmode, gen_rtx_REG(SImode, LP_COUNT)));
+	  emit_insn(gen_rtx_CLOBBER(VOIDmode, gen_rtx_REG(CCmode, CC_REG)));
 	  emit_insn (gen_addsi_compare_2 (operands[1], operands[1]));
 	  emit_insn (gen_sbc (operands[0], operands[0], operands[0]));
 	  return;
@@ -4626,6 +4630,8 @@ arc_split_lshr (rtx *operands)
       else if (n == 30)
 	{
 	  rtx tmp = gen_reg_rtx (SImode);
+	  emit_insn(gen_rtx_CLOBBER(VOIDmode, gen_rtx_REG(SImode, LP_COUNT)));
+	  emit_insn(gen_rtx_CLOBBER(VOIDmode, gen_rtx_REG(CCmode, CC_REG)));
 	  emit_insn (gen_add_f (tmp, operands[1], operands[1]));
 	  emit_insn (gen_scc_ltu_cc_c (operands[0]));
 	  emit_insn (gen_addsi_compare_2 (tmp, tmp));
@@ -4634,6 +4640,8 @@ arc_split_lshr (rtx *operands)
 	}
       else if (n == 31)
 	{
+	  emit_insn(gen_rtx_CLOBBER(VOIDmode, gen_rtx_REG(SImode, LP_COUNT)));
+	  emit_insn(gen_rtx_CLOBBER(VOIDmode, gen_rtx_REG(CCmode, CC_REG)));
 	  emit_insn (gen_addsi_compare_2 (operands[1], operands[1]));
 	  emit_insn (gen_scc_ltu_cc_c (operands[0]));
 	  return;

--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -3398,7 +3398,17 @@ archs4x, archs4xd"
   [(set (match_operand:SI 0 "dest_reg_operand" "")
 	(ANY_SHIFT_ROTATE:SI (match_operand:SI 1 "register_operand" "")
 			     (match_operand:SI 2 "nonmemory_operand" "")))]
-  "")
+  ""
+{
+  /*
+   * Insert clobbers here as the arc_split_ functions aren't invoked
+   * until after CSE where these clobbers are needed.
+   */
+  if (!TARGET_BARREL_SHIFTER) {
+    emit_insn(gen_rtx_CLOBBER(VOIDmode, gen_rtx_REG(SImode, LP_COUNT)));
+    emit_insn(gen_rtx_CLOBBER(VOIDmode, gen_rtx_REG(CCmode, CC_REG)));
+  }
+})
 
 ; asl, asr, lsr patterns:
 ; There is no point in including an 'I' alternative since only the lowest 5

--- a/gcc/config/picolibc-spec.h
+++ b/gcc/config/picolibc-spec.h
@@ -1,5 +1,5 @@
 /* Configuration common to all targets running Picolibc.
-   Copyright (C) 2023 Free Software Foundation, Inc.
+   Copyright (C) 2026 Free Software Foundation, Inc.
 
    This file is part of GCC.
 
@@ -23,15 +23,22 @@
    <http://www.gnu.org/licenses/>.  */
 
 #define PICOLIBC_LD "picolibc.ld"
+#define PICOLIBCPP_LD "picolibcpp.ld"
+
+#define EXCEPT_FILE_ELSE(_except, _noexcept) "%:if-driverlang(c++ " _except " " _noexcept ")"
+#define EXCEPT_FILE(_except) "%:if-driverlang(c++ " _except ")"
+
+#define PICOLIBC_SCRIPT   EXCEPT_FILE_ELSE(PICOLIBCPP_LD, PICOLIBC_LD)
+#define PICOLIBC_CRTEND   EXCEPT_FILE("crtend%O%s")
+#define PICOLIBC_CRTBEGIN EXCEPT_FILE("crtbegin%O%s")
 
 /* Default to local-exec TLS model.  */
 #undef OS_CC1_SPEC
 #define OS_CC1_SPEC " %{!ftls-model=*:-ftls-model=local-exec}"
 
 /* Pass along preprocessor definitions when --printf or --scanf are specified */
-#undef LIBC_CPP_SPEC
 #define LIBC_CPP_SPEC				\
-  "%{-printf=*: -D_PICOLIBC_PRINTF='%*'}"	\
+  " %{-printf=*: -D_PICOLIBC_PRINTF='%*'}"	\
   " %{-scanf=*: -D_PICOLIBC_SCANF='%*'}"
 
 /*
@@ -39,9 +46,8 @@
  * Define vfprintf if --printf is set
  * Define vfscanf if --scanf is set
  */
-#undef LIBC_LINK_SPEC
 #define LIBC_LINK_SPEC							\
-  "%{!shared:%{!r:%{!T*: %:if-exists-then-else(%:find-file(" PICOLIBC_LD ") -T" PICOLIBC_LD ")}}}" \
+  " %{!shared:%{!r:%{!T*: %:if-exists-then-else(%:find-file(" PICOLIBC_SCRIPT ") -T" PICOLIBC_SCRIPT ")}}}" \
   " %{-printf=*:--defsym=" USER_LABEL_PREFIX "vfprintf=" USER_LABEL_PREFIX "__%*_vfprintf}" \
   " %{-scanf=*:--defsym=" USER_LABEL_PREFIX "vfscanf=" USER_LABEL_PREFIX "__%*_vfscanf}"
 
@@ -49,11 +55,14 @@
  * Place the C library, libgcc and any oslib in a link group to resolve
  * interdependencies
  */
-#undef  LIB_SPEC
+#undef LIB_SPEC
 #define LIB_SPEC "--start-group -lc %{-oslib=*:-l%*} %(libgcc) --end-group"
+
+#undef ENDFILE_SPEC
+#define ENDFILE_SPEC PICOLIBC_CRTEND
 
 /* Select alternate crt0 version if --crt0 is specified */
 #undef  STARTFILE_SPEC
-#define STARTFILE_SPEC "%{-crt0=*:crt0-%*%O%s; :crt0%O%s}"
+#define STARTFILE_SPEC "%{-crt0=*:crt0-%*%O%s; :crt0%O%s} " PICOLIBC_CRTBEGIN
 
 #define EH_TABLES_CAN_BE_READ_ONLY 1

--- a/gcc/config/picolibc-spec.h
+++ b/gcc/config/picolibc-spec.h
@@ -47,7 +47,7 @@
  * Define vfscanf if --scanf is set
  */
 #define LIBC_LINK_SPEC							\
-  " %{!shared:%{!r:%{!T*: %:if-exists-then-else(%:find-file(" PICOLIBC_SCRIPT ") -T" PICOLIBC_SCRIPT ")}}}" \
+  " %{!shared:%{!r:%{!T*: %:if-exists-then-else(%:find-file(" PICOLIBC_SCRIPT ") -T%:find-file(" PICOLIBC_SCRIPT "))}}}" \
   " %{-printf=*:--defsym=" USER_LABEL_PREFIX "vfprintf=" USER_LABEL_PREFIX "__%*_vfprintf}" \
   " %{-scanf=*:--defsym=" USER_LABEL_PREFIX "vfscanf=" USER_LABEL_PREFIX "__%*_vfscanf}"
 

--- a/gcc/config/picolibc.opt
+++ b/gcc/config/picolibc.opt
@@ -1,6 +1,6 @@
 ; Processor-independent options for picolibc.
 ;
-; Copyright (C) 2022 Free Software Foundation, Inc.
+; Copyright (C) 2026 Free Software Foundation, Inc.
 ;
 ; This file is part of GCC.
 ;

--- a/gcc/configure
+++ b/gcc/configure
@@ -1004,6 +1004,7 @@ with_changes_root_url
 enable_languages
 with_multilib_list
 with_multilib_generator
+with_picolibc
 with_zstd
 with_zstd_include
 with_zstd_lib
@@ -1885,6 +1886,8 @@ Optional Packages:
                           SH and x86-64 only)
   --with-multilib-generator
                           Multi-libs configuration string (RISC-V only)
+  --with-picolibc         Support for picolibc, including command line options
+                          and spec rules
   --with-zstd=PATH        specify prefix directory for installed zstd library.
                           Equivalent to --with-zstd-include=PATH/include plus
                           --with-zstd-lib=PATH/lib
@@ -8397,6 +8400,13 @@ if test "${with_multilib_generator+set}" = set; then :
   withval=$with_multilib_generator; :
 else
   with_multilib_generator=default
+fi
+
+
+
+# Check whether --with-picolibc was given.
+if test "${with_picolibc+set}" = set; then :
+  withval=$with_picolibc;
 fi
 
 
@@ -21625,7 +21635,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 21614 "configure"
+#line 21638 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -21731,7 +21741,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 21720 "configure"
+#line 21744 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H

--- a/gcc/configure.ac
+++ b/gcc/configure.ac
@@ -1222,6 +1222,9 @@ AC_ARG_WITH(multilib-generator,
 :,
 with_multilib_generator=default)
 
+AC_ARG_WITH(picolibc,
+[AS_HELP_STRING([--with-picolibc], [Support for picolibc, including command line options and spec rules])])
+
 # -------------------------
 # Checks for other programs
 # -------------------------
@@ -2567,10 +2570,6 @@ if { { test x$host != x$target && test "x$with_sysroot" = x ; } ||
        inhibit_libc=true
 fi
 AC_SUBST(inhibit_libc)
-
-AC_ARG_WITH(default-libc,
-	[AS_HELP_STRING([--with-default-libc],
-			[Use specified default C library])])
 
 # When building gcc with a cross-compiler, we need to adjust things so
 # that the generator programs are still built with the native compiler.

--- a/gcc/cp/g++spec.cc
+++ b/gcc/cp/g++spec.cc
@@ -458,3 +458,6 @@ int lang_specific_pre_link (void)  /* Not used for C++.  */
 
 /* Number of extra output files that lang_specific_pre_link may generate.  */
 int lang_specific_extra_outfiles = 0;  /* Not used for C++.  */
+
+/* Language target for this driver */
+const char *lang_specific_language = "c++";

--- a/gcc/d/d-spec.cc
+++ b/gcc/d/d-spec.cc
@@ -525,3 +525,5 @@ lang_specific_pre_link (void)
 
 int lang_specific_extra_outfiles = 0;  /* Not used for D.  */
 
+/* Language target for this driver */
+const char *lang_specific_language = "d";

--- a/gcc/doc/invoke.texi
+++ b/gcc/doc/invoke.texi
@@ -37218,6 +37218,23 @@ intended to be passed to the LTO linker plugin.
 The @code{print-asm-header} function takes no arguments and simply
 prints a banner like:
 
+@item @code{if-driverlang}
+The @code{if-driverlang} spec function takes at least two arguments
+and an optional third one. The first argument is a language name as is
+used with @option{-x}. That is compared with the target language of
+the Compilation Driver, for example the target language for @file{gcc}
+is @samp{c} and the target language for @file{g++} is @samp{c++}. If
+they match, the function returns the second argument. If they do not
+match, the function returns the third argument if there is one, or
+NULL otherwise. This can be used to select general options or linker
+parameters based upon which Compilation Driver was invoked. Here is a
+small example of its usage:
+
+@smallexample
+*startfile:
+crt0%O%s %:if-driverlang(c++ crtbegin%O%s)
+@end smallexample
+
 @smallexample
 Assembler options
 =================

--- a/gcc/fortran/gfortranspec.cc
+++ b/gcc/fortran/gfortranspec.cc
@@ -448,3 +448,6 @@ lang_specific_pre_link (void)
 
 /* Number of extra output files that lang_specific_pre_link may generate.  */
 int lang_specific_extra_outfiles = 0;	/* Not used for F77.  */
+
+/* Language target for this driver */
+const char *lang_specific_language = "f77";

--- a/gcc/gcc.cc
+++ b/gcc/gcc.cc
@@ -459,6 +459,7 @@ static const char *debug_level_greater_than_spec_func (int, const char **);
 static const char *dwarf_version_greater_than_spec_func (int, const char **);
 static const char *find_fortran_preinclude_file (int, const char **);
 static const char *join_spec_func (int, const char **);
+static const char *if_driverlang_spec_function (int, const char **);
 static char *convert_white_space (char *);
 static char *quote_spec (char *);
 static char *quote_spec_arg (char *);
@@ -1805,6 +1806,7 @@ static const struct spec_function static_spec_functions[] =
   { "dwarf-version-gt",		dwarf_version_greater_than_spec_func },
   { "fortran-preinclude-file",	find_fortran_preinclude_file},
   { "join",			join_spec_func},
+  { "if-driverlang",            if_driverlang_spec_function },
 #ifdef EXTRA_SPEC_FUNCTIONS
   EXTRA_SPEC_FUNCTIONS
 #endif
@@ -11112,6 +11114,32 @@ join_spec_func (int argc, const char **argv)
     obstack_grow (&obstack, argv[i], strlen (argv[i]));
   obstack_1grow (&obstack, '\0');
   return XOBFINISH (&obstack, const char *);
+}
+
+/* if-driverlang built-in spec function.
+
+   Checks to see if the language-specific driver has specified a
+   language name that matches the first arg. Returns the second arg if
+   so, otherwise returns the third arg if it is present.  */
+
+static const char *
+if_driverlang_spec_function (int argc, const char **argv)
+{
+  const char *language;
+
+  /* Must have two or three arguments.  */
+  if (argc != 2 && argc != 3)
+    return NULL;
+
+  language = lang_specific_language;
+
+  if (language && !strcmp (argv[0], language))
+    return argv[1];
+
+  if (argc == 3)
+    return argv[2];
+
+  return NULL;
 }
 
 /* If any character in ORIG fits QUOTE_P (_, P), reallocate the string

--- a/gcc/gcc.h
+++ b/gcc/gcc.h
@@ -88,6 +88,9 @@ extern int n_infiles;
 /* Number of extra output files that lang_specific_pre_link may generate.  */
 extern int lang_specific_extra_outfiles;
 
+/* The target language of the current driver, NULL if none */
+extern const char *lang_specific_language;
+
 /* A vector of corresponding output files is made up later.  */
 
 extern const char **outfiles;

--- a/gcc/go/gospec.cc
+++ b/gcc/go/gospec.cc
@@ -460,3 +460,6 @@ int lang_specific_pre_link (void)  /* Not used for Go.  */
 
 /* Number of extra output files that lang_specific_pre_link may generate.  */
 int lang_specific_extra_outfiles = 0;  /* Not used for Go.  */
+
+/* Language target for this driver */
+const char *lang_specific_language = "go";

--- a/gcc/jit/jit-spec.cc
+++ b/gcc/jit/jit-spec.cc
@@ -39,3 +39,6 @@ lang_specific_pre_link (void)
 
 /* Number of extra output files that lang_specific_pre_link may generate.  */
 int lang_specific_extra_outfiles = 0;  /* Not used for jit.  */
+
+/* Language target for this driver */
+const char *lang_specific_language = NULL;

--- a/gcc/m2/gm2spec.cc
+++ b/gcc/m2/gm2spec.cc
@@ -943,3 +943,6 @@ lang_specific_pre_link (void)  /* Not used for M2.  */
 
 /* Number of extra output files that lang_specific_pre_link may generate.  */
 int lang_specific_extra_outfiles = 0;
+
+/* Language target for this driver */
+const char *lang_specific_language = "modula-2";

--- a/gcc/rust/rustspec.cc
+++ b/gcc/rust/rustspec.cc
@@ -189,3 +189,6 @@ lang_specific_pre_link (void) /* Not used for Rust.  */
 
 /* Number of extra output files that lang_specific_pre_link may generate.  */
 int lang_specific_extra_outfiles = 0; /* Not used for Rust.  */
+
+/* Language target for this driver */
+const char *lang_specific_language = "rust";


### PR DESCRIPTION
The GCC project accepted picolibc support for the upcoming version 16 release. That uses --with-picolibc instead of the --with-default-libc=picolibc form used by the Zephyr patches.

This series adapts the upstream form along with another pending patch which makes linking C++ applications include the necessary exception bits.
