### PR TITLE
gcc: Add riscv imfc large code model multi-lib support

### DIFF
--- a/gcc/config/riscv/t-zephyr
+++ b/gcc/config/riscv/t-zephyr
@@ -96,7 +96,9 @@ march=rv64imafdcv_zicsr_zifencei/mabi=lp64d/mcmodel=medany \
 march=rv64imafdcv_zicsr_zifencei/mabi=lp64d/mcmodel=large \
 march=rv64imafd_zicsr_zifencei/mabi=lp64d/mcmodel=medany \
 march=rv64imfc_zicsr_zifencei/mabi=lp64f/mcmodel=medany \
-march=rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi=lp64f/mcmodel=medany
+march=rv64imfc_zicsr_zifencei/mabi=lp64f/mcmodel=large \
+march=rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi=lp64f/mcmodel=medany \
+march=rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi=lp64f/mcmodel=large
 
 # Multilib alternate mapping
 MULTILIB_REUSE = \


### PR DESCRIPTION
Add new multi-lib support for RISC-V IMFC ISA's mcmodel=large, which is needed for systems with more than 2GB memory maps.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
