### PR TITLE
arc: fix shifting without barrel shifter, remove 'round' intrinsic

### DIFF
--- a/gcc/config/arc64/arc64.md
+++ b/gcc/config/arc64/arc64.md
@@ -2866,14 +2866,15 @@ xorl"
 ;; Floating-point intrinsics
 ;; -------------------------------------------------------------------
 
-(define_insn "round<mode>2"
-  [(set (match_operand:GPF 0 "register_operand" "=w")
-	(unspec:GPF [(match_operand:GPF 1 "register_operand" "w")]
-		    ARC64_UNSPEC_ROUND))]
-  "ARC64_HAS_FP_BASE"
-  "f<sfxtab>rnd\\t%0,%1"
-  [(set_attr "length" "4")
-   (set_attr "type" "frnd")])
+;; Cannot use the F*RND instruction as that doesn't round-away
+;;(define_insn "round<mode>2"
+;;  [(set (match_operand:GPF 0 "register_operand" "=w")
+;;	(unspec:GPF [(match_operand:GPF 1 "register_operand" "w")]
+;;		    ARC64_UNSPEC_ROUND))]
+;;  "ARC64_HAS_FP_BASE"
+;;  "f<sfxtab>rnd\\t%0,%1"
+;;  [(set_attr "length" "4")
+;;   (set_attr "type" "frnd")])
 
 (define_insn "btrunc<mode>2"
   [(set (match_operand:GPF 0 "register_operand" "=w")


### PR DESCRIPTION
I thought the barrel shifter fix had been merged, but it's still here in my repo?

And, today I found a bug in the arc64 md file. It advertises support for the 'round' intrinsic (used for round, roundf and roundl), but the arc64 instruction selected has the wrong rounding mode and cannot be fixed, so I disabled the insn so the compiler will fall back to the library implementation.
