### PR TITLE
arc: Clobber CC and LP when shifting without barrel shifter

### DIFF
--- a/gcc/config/arc/arc.cc
+++ b/gcc/config/arc/arc.cc
@@ -4580,6 +4580,8 @@ arc_split_ashr (rtx *operands)
       else if (n == 30)
 	{
 	  rtx tmp = gen_reg_rtx (SImode);
+	  emit_insn(gen_rtx_CLOBBER(VOIDmode, gen_rtx_REG(SImode, LP_COUNT)));
+	  emit_insn(gen_rtx_CLOBBER(VOIDmode, gen_rtx_REG(CCmode, CC_REG)));
 	  emit_insn (gen_add_f (tmp, operands[1], operands[1]));
 	  emit_insn (gen_sbc (operands[0], operands[0], operands[0]));
 	  emit_insn (gen_addsi_compare_2 (tmp, tmp));
@@ -4588,6 +4590,8 @@ arc_split_ashr (rtx *operands)
 	}
       else if (n == 31)
 	{
+	  emit_insn(gen_rtx_CLOBBER(VOIDmode, gen_rtx_REG(SImode, LP_COUNT)));
+	  emit_insn(gen_rtx_CLOBBER(VOIDmode, gen_rtx_REG(CCmode, CC_REG)));
 	  emit_insn (gen_addsi_compare_2 (operands[1], operands[1]));
 	  emit_insn (gen_sbc (operands[0], operands[0], operands[0]));
 	  return;
@@ -4626,6 +4630,8 @@ arc_split_lshr (rtx *operands)
       else if (n == 30)
 	{
 	  rtx tmp = gen_reg_rtx (SImode);
+	  emit_insn(gen_rtx_CLOBBER(VOIDmode, gen_rtx_REG(SImode, LP_COUNT)));
+	  emit_insn(gen_rtx_CLOBBER(VOIDmode, gen_rtx_REG(CCmode, CC_REG)));
 	  emit_insn (gen_add_f (tmp, operands[1], operands[1]));
 	  emit_insn (gen_scc_ltu_cc_c (operands[0]));
 	  emit_insn (gen_addsi_compare_2 (tmp, tmp));
@@ -4634,6 +4640,8 @@ arc_split_lshr (rtx *operands)
 	}
       else if (n == 31)
 	{
+	  emit_insn(gen_rtx_CLOBBER(VOIDmode, gen_rtx_REG(SImode, LP_COUNT)));
+	  emit_insn(gen_rtx_CLOBBER(VOIDmode, gen_rtx_REG(CCmode, CC_REG)));
 	  emit_insn (gen_addsi_compare_2 (operands[1], operands[1]));
 	  emit_insn (gen_scc_ltu_cc_c (operands[0]));
 	  return;

--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -3398,7 +3398,17 @@ archs4x, archs4xd"
   [(set (match_operand:SI 0 "dest_reg_operand" "")
 	(ANY_SHIFT_ROTATE:SI (match_operand:SI 1 "register_operand" "")
 			     (match_operand:SI 2 "nonmemory_operand" "")))]
-  "")
+  ""
+{
+  /*
+   * Insert clobbers here as the arc_split_ functions aren't invoked
+   * until after CSE where these clobbers are needed.
+   */
+  if (!TARGET_BARREL_SHIFTER) {
+    emit_insn(gen_rtx_CLOBBER(VOIDmode, gen_rtx_REG(SImode, LP_COUNT)));
+    emit_insn(gen_rtx_CLOBBER(VOIDmode, gen_rtx_REG(CCmode, CC_REG)));
+  }
+})
 
 ; asl, asr, lsr patterns:
 ; There is no point in including an 'I' alternative since only the lowest 5


### PR DESCRIPTION
Devices without a barrel shifter end up using a sequence of instructions. These can use the condition codes and/or loop count register, so those need to be marked as 'clobbered'.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
