### PR TITLE
xtensa: fix lsi from literal pools on Harvard-architecture SoCs

### DIFF
--- a/gcc/config/xtensa/xtensa.md
+++ b/gcc/config/xtensa/xtensa.md
@@ -1450,8 +1450,8 @@
 })
 
 (define_insn "movsf_internal"
-  [(set (match_operand:SF 0 "nonimmed_operand" "=f,f,U,D,D,R,a,f,a,a,W,a,a,U")
-	(match_operand:SF 1 "move_operand" "f,U,f,d,R,d,r,r,f,Y,iF,T,U,r"))]
+  [(set (match_operand:SF 0 "nonimmed_operand" "=f,f,U,D,a,D,R,a,f,a,a,W,a,U")
+	(match_operand:SF 1 "move_operand" "f,^U,f,d,T,R,d,r,r,f,Y,iF,U,r"))]
   "((register_operand (operands[0], SFmode)
      || register_operand (operands[1], SFmode))
     && !(FP_REG_P (xt_true_regnum (operands[0]))
@@ -1461,6 +1461,7 @@
    %v1lsi\t%0, %1
    %v0ssi\t%1, %0
    mov.n\t%0, %1
+   %v1l32r\t%0, %1
    %v1l32i.n\t%0, %1
    %v0s32i.n\t%1, %0
    mov\t%0, %1
@@ -1468,12 +1469,11 @@
    rfr\t%0, %1
    movi\t%0, %y1
    const16\t%0, %t1\;const16\t%0, %b1
-   %v1l32r\t%0, %1
    %v1l32i\t%0, %1
    %v0s32i\t%1, %0"
-  [(set_attr "type"	"farith,fload,fstore,move,load,store,move,farith,farith,move,move,load,load,store")
+  [(set_attr "type"	"farith,fload,fstore,move,load,load,store,move,farith,farith,move,move,load,store")
    (set_attr "mode"	"SF")
-   (set_attr "length"	"3,3,3,2,2,2,3,3,3,3,6,3,3,3")])
+   (set_attr "length"	"3,3,3,2,3,2,2,3,3,3,3,6,3,3")])
 
 (define_insn "*lsiu"
   [(set (match_operand:SF 0 "register_operand" "=f")


### PR DESCRIPTION
Backport upstream GCC 15 commit fb7b82964f54 to fix a crash on Xtensa SoCs with split instruction/data buses (ESP32, ESP32-S3).

After the transition to LRA (Local Register Allocator), the register allocator aggressively selects the f,U alternative in movsf_internal, generating lsi (FPU load) instructions to read float constants from literal pools. On Harvard-architecture Xtensa SoCs, literal pools are placed in IROM which is only accessible via the instruction bus. The lsi instruction uses the data bus, causing EXCCAUSE 3 (load/store error) at runtime.

Add '^' constraint modifier to the source U operand in the f,U alternative, discouraging LRA from selecting the lsi path for constant pool loads. Reorder alternatives so a,T (l32r into AR register) is preferred over D,R (l32i.n) for constant pool access, resulting in the correct l32r + wfr sequence.

Upstream fix: https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=fb7b82964f54
Upstream cleanup: https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=2e5130f6870b

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
