### PR TITLE
zephyr: xtensa: enable multilib to build for call0 ABI

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -3627,6 +3627,11 @@ xstormy16-*-elf)
 	extra_options=stormy16/stormy16.opt
 	tmake_file="stormy16/t-stormy16"
 	;;
+xtensa*-*_zephyr-elf*)
+	tm_file="${tm_file} elfos.h newlib-stdint.h xtensa/zephyr.h"
+	extra_options="${extra_options} xtensa/elf.opt"
+	tmake_file="${tmake_file} xtensa/t-zephyr"
+	;;
 xtensa*-*-elf*)
 	tm_file="${tm_file} elfos.h newlib-stdint.h xtensa/elf.h"
 	extra_options="${extra_options} xtensa/elf.opt"

--- a/gcc/config/xtensa/t-zephyr
+++ b/gcc/config/xtensa/t-zephyr
@@ -1,0 +1,47 @@
+# Copyright (C) 2002-2024 Free Software Foundation, Inc.
+#
+# This file is part of GCC.
+#
+# GCC is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# GCC is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GCC; see the file COPYING3.  If not see
+# <http://www.gnu.org/licenses/>.
+
+TM_H += $(srcdir)/../include/xtensa-config.h \
+	$(srcdir)/../include/xtensa-dynconfig.h
+$(out_object_file): gt-xtensa.h
+
+xtensa-dynconfig.o: $(srcdir)/config/xtensa/xtensa-dynconfig.cc
+	$(COMPILE) $<
+	$(POSTCOMPILE)
+
+XTENSA_CONFIG_H = $(srcdir)/ginclude/core-isa.h
+
+stmp-xtensa-int-hdrs: $(XTENSA_CONFIG_H)
+	-if [ -d include ] ; then true; else mkdir include; chmod a+rx include; fi
+	-if [ -d include/xtensa ] ; then true; else mkdir include/xtensa; chmod a+rx include/xtensa; fi
+	-if [ -d include/xtensa/config ] ; then true; else mkdir include/xtensa/config; chmod a+rx include/xtensa/config; fi
+	for file in .. $(XTENSA_CONFIG_H); do \
+	  if [ X$$file != X.. ]; then \
+	    realfile=`echo $$file | sed -e 's|.*/\([^/]*\)$$|\1|'`; \
+	    $(STAMP) include/xtensa/config/$$realfile; \
+	    rm -f include/xtensa/config/$$realfile; \
+	    cp $$file include/xtensa/config; \
+	    chmod a+r include/xtensa/config/$$realfile; \
+	  fi; \
+	done
+	$(STAMP) $@
+
+stmp-int-hdrs: stmp-xtensa-int-hdrs
+
+MULTILIB_OPTIONS += mabi=call0/mabi=windowed
+MULTILIB_DIRNAMES += call0 windowed

--- a/gcc/config/xtensa/zephyr.h
+++ b/gcc/config/xtensa/zephyr.h
@@ -1,0 +1,105 @@
+/* Xtensa/Elf configuration.
+   Derived from the configuration for GCC for Intel i386 running Linux.
+   Copyright (C) 2001-2024 Free Software Foundation, Inc.
+
+This file is part of GCC.
+
+GCC is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with GCC; see the file COPYING3.  If not see
+<http://www.gnu.org/licenses/>.  */
+
+#define TARGET_SECTION_TYPE_FLAGS xtensa_multibss_section_type_flags
+
+#undef ASM_APP_ON
+#define ASM_APP_ON "#APP\n"
+
+#undef ASM_APP_OFF
+#define ASM_APP_OFF "#NO_APP\n"
+
+#undef SIZE_TYPE
+#define SIZE_TYPE "unsigned int"
+
+#undef PTRDIFF_TYPE
+#define PTRDIFF_TYPE "int"
+
+#undef WCHAR_TYPE
+#define WCHAR_TYPE "short unsigned int"
+
+#undef WCHAR_TYPE_SIZE
+#define WCHAR_TYPE_SIZE 16
+
+#undef ASM_SPEC
+#define ASM_SPEC \
+ "%{mtext-section-literals:--text-section-literals} \
+  %{mno-text-section-literals:--no-text-section-literals} \
+  %{mtarget-align:--target-align} \
+  %{mno-target-align:--no-target-align} \
+  %{mlongcalls:--longcalls} \
+  %{mno-longcalls:--no-longcalls} \
+  %{mauto-litpools:--auto-litpools} \
+  %{mno-auto-litpools:--no-auto-litpools} \
+  %{mabi=windowed:--abi-windowed} \
+  %{mabi=call0:--abi-call0}"
+
+#undef MULTILIB_DEFAULTS
+#define MULTILIB_DEFAULTS { "mabi=windowed" }
+
+#undef LIB_SPEC
+#define LIB_SPEC "-lc -lsim -lc -lhandlers-sim -lhal"
+
+#undef STARTFILE_SPEC
+#define STARTFILE_SPEC \
+  "crt1-sim%O%s crt0%O%s crti%O%s crtbegin%O%s _vectors%O%s"
+
+#undef ENDFILE_SPEC
+#define ENDFILE_SPEC "crtend%O%s crtn%O%s"
+
+#undef LINK_SPEC
+#define LINK_SPEC \
+ "%{shared:-shared} \
+  %{!shared: \
+    %{!static: \
+      %{rdynamic:-export-dynamic} \
+    %{static:-static}}} \
+  %{mabi=windowed:--abi-windowed} \
+  %{mabi=call0:--abi-call0}"
+
+#undef LOCAL_LABEL_PREFIX
+#define LOCAL_LABEL_PREFIX	"."
+
+/* Avoid dots for compatibility with VxWorks.  */
+#undef NO_DOLLAR_IN_LABEL
+#define NO_DOT_IN_LABEL
+
+/* Do not force "-fpic" for this target.  */
+#define XTENSA_ALWAYS_PIC 0
+
+#undef DEBUGGER_REGNO
+
+/* Search for headers in $tooldir/arch/include and for libraries and
+   startfiles in $tooldir/arch/lib.  */
+#define GCC_DRIVER_HOST_INITIALIZATION \
+  do { \
+    char *tooldir, *archdir; \
+    tooldir = concat (tooldir_base_prefix, spec_machine, \
+		      dir_separator_str, NULL); \
+    if (!IS_ABSOLUTE_PATH (tooldir)) \
+      tooldir = concat (standard_exec_prefix, spec_machine, dir_separator_str, \
+			spec_version, dir_separator_str, tooldir, NULL); \
+    archdir = concat (tooldir, "arch", dir_separator_str, NULL); \
+    add_prefix (&startfile_prefixes, \
+		concat (archdir, "lib", dir_separator_str, NULL), \
+		"GCC", PREFIX_PRIORITY_LAST, 0, 1); \
+    add_prefix (&include_prefixes, archdir, \
+		"GCC", PREFIX_PRIORITY_LAST, 0, 0); \
+  } while (0)


### PR DESCRIPTION
This enables multilib builds for Zephyr Xtensa toolchains supporting both CALL0 and Windowed ABIs, where Windowed ABI is the default.
