### PR TITLE
RISC-V: Add rv64-imafc multi-lib support

### DIFF
--- a/gcc/config/riscv/t-zephyr
+++ b/gcc/config/riscv/t-zephyr
@@ -40,6 +40,8 @@ MULTILIB_SRC_ARCH += rv64ima_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv64ima_zicsr_zifencei_zba_zbb_zbc_zbs
 MULTILIB_SRC_ARCH += rv64imac_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv64imac_zicsr_zifencei_zba_zbb_zbc_zbs
+MULTILIB_SRC_ARCH += rv64imafc_zicsr_zifencei
+MULTILIB_SRC_ARCH += rv64imafc_zicsr_zifencei_zba_zbb_zbc_zbs
 MULTILIB_SRC_ARCH += rv64imafd_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv64imafdc_zicsr_zifencei
 MULTILIB_SRC_ARCH += rv64imafdc_zicsr_zifencei_zba_zbb_zbc_zbs
@@ -98,7 +100,11 @@ march=rv64imafd_zicsr_zifencei/mabi=lp64d/mcmodel=medany \
 march=rv64imfc_zicsr_zifencei/mabi=lp64f/mcmodel=medany \
 march=rv64imfc_zicsr_zifencei/mabi=lp64f/mcmodel=large \
 march=rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi=lp64f/mcmodel=medany \
-march=rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi=lp64f/mcmodel=large
+march=rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi=lp64f/mcmodel=large \
+march=rv64imafc_zicsr_zifencei/mabi=lp64f/mcmodel=medany \
+march=rv64imafc_zicsr_zifencei/mabi=lp64f/mcmodel=large \
+march=rv64imafc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi=lp64f/mcmodel=medany \
+march=rv64imafc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi=lp64f/mcmodel=large
 
 # Multilib alternate mapping
 MULTILIB_REUSE = \
@@ -131,6 +137,8 @@ march.rv64imafdc_zicsr_zifencei/mabi.lp64d/mcmodel.medany=march.rv64imafdc_zicsr
 march.rv64imafdc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64d/mcmodel.medany=march.rv64imafdc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64d \
 march.rv64imafdcv_zicsr_zifencei/mabi.lp64d/mcmodel.medany=march.rv64imafdcv_zicsr_zifencei/mabi.lp64d \
 march.rv64imafd_zicsr_zifencei/mabi.lp64d/mcmodel.medany=march.rv64imafd_zicsr_zifencei/mabi.lp64d \
+march.rv64imafc_zicsr_zifencei/mabi.lp64f/mcmodel.medany=march.rv64imafc_zicsr_zifencei/mabi.lp64f \
+march.rv64imafc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64f/mcmodel.medany=march.rv64imafc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64f \
 march.rv64imfc_zicsr_zifencei/mabi.lp64f/mcmodel.medany=march.rv64imfc_zicsr_zifencei/mabi.lp64f \
 march.rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64f/mcmodel.medany=march.rv64imfc_zicsr_zifencei_zba_zbb_zbc_zbs/mabi.lp64f \
 march.rv64i_zicsr_zifencei/mabi.lp64/mcmodel.medany=march.rv64ia_zicsr_zifencei/mabi.lp64/mcmodel.medany \


### PR DESCRIPTION
Add new multi-lib support for RISC-V IMAFC ISA's, which is needed for systems without double precision support.

Change-Id: I475de49e86435234d3aac3f81479d9d147a1363d

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
