### PR TITLE
RISC-V: Add T-Head E907 core and extension support

### DIFF
--- a/gcc/common/config/riscv/riscv-common.cc
+++ b/gcc/common/config/riscv/riscv-common.cc
@@ -184,6 +184,21 @@ static const riscv_implied_info_t riscv_implied_info[] =
      return subset_list->xlen () == 32 && subset_list->lookup ("f");
    }},
 
+  {"xtheade", "xtheadcmo"},
+  {"xtheade", "xtheadsync"},
+  {"xtheade", "xtheadba"},
+  {"xtheade", "xtheadbb"},
+  {"xtheade", "xtheadbs"},
+  {"xtheade", "xtheadcondmov"},
+  {"xtheade", "xtheadmemidx"},
+  {"xtheade", "xtheadfmv"},
+  {"xtheade", "xtheadmac"},
+  {"xtheade", "xtheadint"},
+
+  {"zpsfoperand", "zpn",
+   [] (const riscv_subset_list *subset_list) -> bool
+   { return subset_list->xlen () == 32; }},
+
   {"smaia", "ssaia"},
   {"smstateen", "ssstateen"},
   {"smepmp", "zicsr"},
@@ -349,6 +364,9 @@ static const struct riscv_ext_version riscv_ext_version_table[] =
   {"zcmp", ISA_SPEC_CLASS_NONE, 1, 0},
   {"zcmt", ISA_SPEC_CLASS_NONE, 1, 0},
 
+  {"zpn", ISA_SPEC_CLASS_NONE, 0, 9},
+  {"zpsfoperand", ISA_SPEC_CLASS_NONE, 0, 9},
+
   {"smaia",     ISA_SPEC_CLASS_NONE, 1, 0},
   {"smepmp",    ISA_SPEC_CLASS_NONE, 1, 0},
   {"smstateen", ISA_SPEC_CLASS_NONE, 1, 0},
@@ -368,6 +386,7 @@ static const struct riscv_ext_version riscv_ext_version_table[] =
   {"xcvsimd", ISA_SPEC_CLASS_NONE, 1, 0},
   {"xcvbi", ISA_SPEC_CLASS_NONE, 1, 0},
 
+  {"xtheade", ISA_SPEC_CLASS_NONE, 1, 0},
   {"xtheadba", ISA_SPEC_CLASS_NONE, 1, 0},
   {"xtheadbb", ISA_SPEC_CLASS_NONE, 1, 0},
   {"xtheadbs", ISA_SPEC_CLASS_NONE, 1, 0},
@@ -1633,6 +1652,9 @@ static const riscv_ext_flag_table_t riscv_ext_flag_table[] =
   {"zcmp",    &gcc_options::x_riscv_zc_subext, MASK_ZCMP},
   {"zcmt",    &gcc_options::x_riscv_zc_subext, MASK_ZCMT},
 
+  {"zpn",          &gcc_options::x_riscv_xthead_subext, MASK_ZPN},
+  {"zpsfoperand",  &gcc_options::x_riscv_xthead_subext, MASK_ZPSFOPERAND},
+
   {"svinval", &gcc_options::x_riscv_sv_subext, MASK_SVINVAL},
   {"svnapot", &gcc_options::x_riscv_sv_subext, MASK_SVNAPOT},
 
@@ -1644,6 +1666,7 @@ static const riscv_ext_flag_table_t riscv_ext_flag_table[] =
   {"xcvsimd",       &gcc_options::x_riscv_xcv_subext, MASK_XCVSIMD},
   {"xcvbi",         &gcc_options::x_riscv_xcv_subext, MASK_XCVBI},
 
+  {"xtheade",       &gcc_options::x_riscv_xthead_subext, MASK_XTHEADE},
   {"xtheadba",      &gcc_options::x_riscv_xthead_subext, MASK_XTHEADBA},
   {"xtheadbb",      &gcc_options::x_riscv_xthead_subext, MASK_XTHEADBB},
   {"xtheadbs",      &gcc_options::x_riscv_xthead_subext, MASK_XTHEADBS},

--- a/gcc/config/riscv/riscv-cores.def
+++ b/gcc/config/riscv/riscv-cores.def
@@ -40,6 +40,7 @@ RISCV_TUNE("sifive-7-series", sifive_7, sifive_7_tune_info)
 RISCV_TUNE("sifive-p400-series", sifive_p400, sifive_p400_tune_info)
 RISCV_TUNE("sifive-p600-series", sifive_p600, sifive_p600_tune_info)
 RISCV_TUNE("thead-c906", generic, thead_c906_tune_info)
+RISCV_TUNE("thead-e907", generic, thead_e907_tune_info)
 RISCV_TUNE("xiangshan-nanhu", xiangshan, xiangshan_nanhu_tune_info)
 RISCV_TUNE("generic-ooo", generic_ooo, generic_ooo_tune_info)
 RISCV_TUNE("size", generic, optimize_size_tune_info)
@@ -91,6 +92,13 @@ RISCV_CORE("thead-c906",      "rv64imafdc_xtheadba_xtheadbb_xtheadbs_xtheadcmo_"
 			      "xtheadcondmov_xtheadfmemidx_xtheadmac_"
 			      "xtheadmemidx_xtheadmempair_xtheadsync",
 			      "thead-c906")
+
+RISCV_CORE("thead-e907",      "rv32imac_zicntr_zicsr_zifencei_zihpm_xtheade",
+			      "thead-e907")
+RISCV_CORE("e907",            "rv32imac_zicntr_zicsr_zifencei_zihpm_xtheade",
+			      "thead-e907")
+RISCV_CORE("e907fp",          "rv32imafc_zicntr_zicsr_zifencei_zihpm_zpsfoperand_xtheade",
+			      "thead-e907")
 
 RISCV_CORE("xiangshan-nanhu",      "rv64imafdc_zba_zbb_zbc_zbs_"
 			      "zbkb_zbkc_zbkx_zknd_zkne_zknh_zksed_zksh_"

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -488,13 +488,30 @@ static const struct riscv_tune_param thead_c906_tune_info = {
   {COSTS_N_INSNS (20), COSTS_N_INSNS (20)}, /* fp_div */
   {COSTS_N_INSNS (4), COSTS_N_INSNS (4)}, /* int_mul */
   {COSTS_N_INSNS (18), COSTS_N_INSNS (34)}, /* int_div */
-  1,            /* issue_rate */
-  3,            /* branch_cost */
-  5,            /* memory_cost */
-  8,		/* fmv_cost */
-  false,            /* slow_unaligned_access */
-  false,	/* use_divmod_expansion */
-  RISCV_FUSE_NOTHING,                           /* fusible_ops */
+  1,						/* issue_rate */
+  3,						/* branch_cost */
+  5,						/* memory_cost */
+  8,						/* fmv_cost */
+  false,					/* slow_unaligned_access */
+  false,					/* use_divmod_expansion */
+  RISCV_FUSE_NOTHING,  /* fusible_ops */
+  NULL,						/* vector cost */
+};
+
+/* Costs to use when optimizing for T-HEAD e907.  */
+static const struct riscv_tune_param thead_e907_tune_info = {
+  {COSTS_N_INSNS (4), COSTS_N_INSNS (5)}, /* fp_add */
+  {COSTS_N_INSNS (4), COSTS_N_INSNS (5)}, /* fp_mul */
+  {COSTS_N_INSNS (20), COSTS_N_INSNS (20)}, /* fp_div */
+  {COSTS_N_INSNS (4), COSTS_N_INSNS (4)}, /* int_mul */
+  {COSTS_N_INSNS (6), COSTS_N_INSNS (6)}, /* int_div */
+  1,						/* issue_rate */
+  3,						/* branch_cost */
+  5,						/* memory_cost */
+  8,						/* fmv_cost */
+  true,						/* slow_unaligned_access */
+  true,						/* use_divmod_expansion */
+  RISCV_FUSE_NOTHING,				/* fusible_ops */
   NULL,						/* vector cost */
 };
 

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -484,6 +484,12 @@ Mask(XTHEADSYNC)    Var(riscv_xthead_subext)
 
 Mask(XTHEADVECTOR)  Var(riscv_xthead_subext)
 
+Mask(XTHEADE)       Var(riscv_xthead_subext)
+
+Mask(ZPN)           Var(riscv_xthead_subext)
+
+Mask(ZPSFOPERAND)   Var(riscv_xthead_subext)
+
 TargetVariable
 int riscv_xventana_subext
 


### PR DESCRIPTION
Add support for the T-Head xtheade vendor extension which serves as an umbrella for common T-Head extensions (xtheadcmo, xtheadsync, xtheadba, xtheadbb, xtheadbs, xtheadcondmov, xtheadmemidx, xtheadfmv, xtheadmac, xtheadint).

Add Zpn and Zpsfoperand P-extension subsets (version 0.9).

Add T-Head E907 RV32 core definitions and tuning parameters with three variants: thead-e907, e907, and e907fp (with floating-point and Zpsfoperand).